### PR TITLE
Fix core bugs: CLI registry, diff engine, harness lifecycle, async parity

### DIFF
--- a/docs/GOLDEN_PATH.md
+++ b/docs/GOLDEN_PATH.md
@@ -21,6 +21,9 @@ insidellms doctor
 
 ### 2) Run a deterministic harness (offline)
 
+Harness runs default to `~/.insidellms/runs/<run_id>/` unless you pass `--run-dir`,
+`--run-root`, or set `output_dir` in the config (relative to the config file).
+
 ```bash
 insidellms harness ci/harness.yaml --run-dir .tmp/runs/baseline --overwrite
 insidellms report .tmp/runs/baseline

--- a/insideLLMs/cli/_parsing.py
+++ b/insideLLMs/cli/_parsing.py
@@ -202,8 +202,19 @@ def create_parser() -> argparse.ArgumentParser:
         "--concurrency",
         "-c",
         type=int,
-        default=5,
+        default=None,
         help="Number of concurrent requests (only with --async)",
+    )
+    run_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Per-item timeout in seconds (only with --async)",
+    )
+    run_parser.add_argument(
+        "--stop-on-error",
+        action="store_true",
+        help="Stop the run after the first item error",
     )
     run_parser.add_argument(
         "--verbose",

--- a/insideLLMs/cli/_record_utils.py
+++ b/insideLLMs/cli/_record_utils.py
@@ -9,18 +9,31 @@ from insideLLMs._serialization import (
     StrictSerializationError,
 )
 from insideLLMs._serialization import (
-    fingerprint_value as _fingerprint_value,
-)
-from insideLLMs._serialization import (
     serialize_value as _serialize_value,
 )
 from insideLLMs._serialization import (
     stable_json_dumps as _stable_json_dumps,
 )
+from insideLLMs.runtime import diffing as _runtime_diffing
 from insideLLMs.types import (
     ProbeCategory,
     ResultStatus,
 )
+
+_record_key = _runtime_diffing._record_key
+_record_label = _runtime_diffing._record_label
+_status_string = _runtime_diffing._status_string
+_output_text = _runtime_diffing._output_text
+_strip_volatile_keys = _runtime_diffing._strip_volatile_keys
+_output_summary = _runtime_diffing._output_summary
+_output_fingerprint = _runtime_diffing._output_fingerprint
+_trace_fingerprint = _runtime_diffing._trace_fingerprint
+_trace_violations = _runtime_diffing._trace_violations
+_trace_violation_count = _runtime_diffing._trace_violation_count
+_primary_score = _runtime_diffing._primary_score
+_metric_mismatch_reason = _runtime_diffing._metric_mismatch_reason
+_metric_mismatch_context = _runtime_diffing._metric_mismatch_context
+_metric_mismatch_details = _runtime_diffing._metric_mismatch_details
 
 
 def _json_default(obj: Any) -> Any:
@@ -93,262 +106,3 @@ def _read_jsonl_records(path: Path) -> list[dict[str, Any]]:
             if isinstance(obj, dict):
                 records.append(obj)
     return records
-
-
-def _record_key(record: dict[str, Any]) -> tuple[str, str, str]:
-    """Extract a unique key tuple from a result record."""
-    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-    harness = custom.get("harness") if isinstance(custom.get("harness"), dict) else {}
-    model_spec = record.get("model") if isinstance(record.get("model"), dict) else {}
-    probe_spec = record.get("probe") if isinstance(record.get("probe"), dict) else {}
-
-    model_id = (
-        harness.get("model_id")
-        or model_spec.get("model_id")
-        or harness.get("model_name")
-        or "model"
-    )
-    probe_id = (
-        harness.get("probe_type")
-        or probe_spec.get("probe_id")
-        or harness.get("probe_name")
-        or "probe"
-    )
-    replicate_key = custom.get("replicate_key")
-    example_id = record.get("example_id") or harness.get("example_index")
-    stable_id = record.get("messages_hash") or _fingerprint_value(record.get("input"))
-    chosen_id = replicate_key or stable_id or example_id or "0"
-    return (str(model_id), str(probe_id), str(chosen_id))
-
-
-def _record_label(record: dict[str, Any]) -> tuple[str, str, str]:
-    """Extract human-readable labels from a result record."""
-    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-    harness = custom.get("harness") if isinstance(custom.get("harness"), dict) else {}
-    model_spec = record.get("model") if isinstance(record.get("model"), dict) else {}
-    probe_spec = record.get("probe") if isinstance(record.get("probe"), dict) else {}
-
-    model_name = harness.get("model_name") or model_spec.get("model_id") or "model"
-    model_id = harness.get("model_id") or model_spec.get("model_id")
-    if model_id and model_id != model_name:
-        model_label = f"{model_name} ({model_id})"
-    else:
-        model_label = str(model_name)
-
-    probe_name = harness.get("probe_name") or probe_spec.get("probe_id") or "probe"
-    example_id = record.get("example_id") or harness.get("example_index") or "0"
-    return (str(model_label), str(probe_name), str(example_id))
-
-
-def _status_string(record: dict[str, Any]) -> str:
-    status = record.get("status")
-    return str(status) if status is not None else "unknown"
-
-
-def _output_text(record: dict[str, Any]) -> Optional[str]:
-    output_text = record.get("output_text")
-    if isinstance(output_text, str):
-        return output_text
-    output = record.get("output")
-    if isinstance(output, str):
-        return output
-    if isinstance(output, dict):
-        value = output.get("output_text") or output.get("text")
-        if isinstance(value, str):
-            return value
-    return None
-
-
-def _strip_volatile_keys(value: Any, ignore_keys: set[str]) -> Any:
-    if isinstance(value, dict):
-        cleaned: dict[str, Any] = {}
-        for key, item in value.items():
-            key_str = str(key).lower()
-            if key_str in ignore_keys:
-                continue
-            cleaned[key] = _strip_volatile_keys(item, ignore_keys)
-        return cleaned
-    if isinstance(value, list):
-        return [_strip_volatile_keys(item, ignore_keys) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_strip_volatile_keys(item, ignore_keys) for item in value)
-    return value
-
-
-def _output_summary(
-    record: dict[str, Any], ignore_keys: Optional[set[str]]
-) -> Optional[dict[str, Any]]:
-    from ._output import _trim_text
-
-    output_text = _output_text(record)
-    if isinstance(output_text, str):
-        return {"type": "text", "preview": _trim_text(output_text), "length": len(output_text)}
-    output = record.get("output")
-    if output is None:
-        return None
-    return {
-        "type": "structured",
-        "fingerprint": _output_fingerprint(record, ignore_keys=ignore_keys),
-    }
-
-
-def _output_fingerprint(
-    record: dict[str, Any], ignore_keys: Optional[set[str]] = None
-) -> Optional[str]:
-    output = record.get("output")
-    if ignore_keys:
-        custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-        override = custom.get("output_fingerprint")
-        if output is None and isinstance(override, str):
-            return override
-        if output is None:
-            return None
-        sanitized = _strip_volatile_keys(output, ignore_keys)
-        return _fingerprint_value(sanitized)
-
-    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-    override = custom.get("output_fingerprint")
-    if isinstance(override, str):
-        return override
-    if output is None:
-        return None
-    return _fingerprint_value(output)
-
-
-def _trace_fingerprint(record: dict[str, Any]) -> Optional[str]:
-    """Extract trace fingerprint from ResultRecord.custom."""
-    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-    fp = custom.get("trace_fingerprint")
-    if isinstance(fp, str):
-        return fp
-
-    trace = custom.get("trace") if isinstance(custom.get("trace"), dict) else {}
-    fingerprint = trace.get("fingerprint") if isinstance(trace.get("fingerprint"), dict) else {}
-    value = fingerprint.get("value")
-    if not isinstance(value, str) or not value:
-        return None
-    # If the bundle stores raw 64-hex without prefix, normalize to the legacy "sha256:<hex>" form.
-    if ":" not in value and len(value) == 64:
-        return f"sha256:{value}"
-    return value
-
-
-def _trace_violations(record: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract trace violations from ResultRecord.custom."""
-    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-    violations = custom.get("trace_violations")
-    if isinstance(violations, list):
-        return violations
-
-    trace = custom.get("trace") if isinstance(custom.get("trace"), dict) else {}
-    violations = trace.get("violations")
-    return violations if isinstance(violations, list) else []
-
-
-def _trace_violation_count(record: dict[str, Any]) -> int:
-    """Count trace violations in a record."""
-    return len(_trace_violations(record))
-
-
-def _primary_score(record: dict[str, Any]) -> tuple[Optional[str], Optional[float]]:
-    scores = record.get("scores") if isinstance(record.get("scores"), dict) else {}
-    metric = record.get("primary_metric")
-    if metric and metric in scores and isinstance(scores[metric], (int, float)):
-        return str(metric), float(scores[metric])
-    if "score" in scores and isinstance(scores["score"], (int, float)):
-        return "score", float(scores["score"])
-    return None, None
-
-
-def _metric_mismatch_reason(record_a: dict[str, Any], record_b: dict[str, Any]) -> Optional[str]:
-    scores_a = record_a.get("scores")
-    scores_b = record_b.get("scores")
-    if not isinstance(scores_a, dict) or not isinstance(scores_b, dict):
-        return "type_mismatch"
-
-    keys_a = sorted(scores_a.keys())
-    keys_b = sorted(scores_b.keys())
-    if not keys_a or not keys_b:
-        return "missing_scores"
-
-    primary_a = record_a.get("primary_metric")
-    primary_b = record_b.get("primary_metric")
-    if primary_a and primary_b and primary_a != primary_b:
-        return "primary_metric_mismatch"
-    if not primary_a or not primary_b:
-        return "missing_primary_metric"
-
-    if primary_a not in scores_a or primary_b not in scores_b:
-        return "metric_key_missing"
-
-    value_a = scores_a.get(primary_a)
-    value_b = scores_b.get(primary_b)
-    if not isinstance(value_a, (int, float)) or not isinstance(value_b, (int, float)):
-        return "non_numeric_metric"
-
-    return "type_mismatch"
-
-
-def _metric_mismatch_context(record_a: dict[str, Any], record_b: dict[str, Any]) -> dict[str, Any]:
-    scores_a = record_a.get("scores")
-    scores_b = record_b.get("scores")
-    primary_a = record_a.get("primary_metric")
-    primary_b = record_b.get("primary_metric")
-
-    keys_a = sorted(scores_a.keys()) if isinstance(scores_a, dict) else None
-    keys_b = sorted(scores_b.keys()) if isinstance(scores_b, dict) else None
-
-    context = {
-        "baseline": {
-            "primary_metric": primary_a,
-            "scores_keys": keys_a,
-            "metric_value": scores_a.get(primary_a) if isinstance(scores_a, dict) else None,
-        },
-        "candidate": {
-            "primary_metric": primary_b,
-            "scores_keys": keys_b,
-            "metric_value": scores_b.get(primary_b) if isinstance(scores_b, dict) else None,
-        },
-    }
-
-    custom = record_a.get("custom") if isinstance(record_a.get("custom"), dict) else {}
-    replicate_key = custom.get("replicate_key")
-    if replicate_key:
-        context["replicate_key"] = replicate_key
-
-    return context
-
-
-def _metric_mismatch_details(record_a: dict[str, Any], record_b: dict[str, Any]) -> str:
-    context = _metric_mismatch_context(record_a, record_b)
-
-    baseline = context.get("baseline", {})
-    candidate = context.get("candidate", {})
-    details = [
-        f"baseline.primary_metric={baseline.get('primary_metric')!r}",
-        f"candidate.primary_metric={candidate.get('primary_metric')!r}",
-    ]
-
-    if baseline.get("scores_keys") is not None:
-        details.append(f"baseline.scores keys={baseline.get('scores_keys')!r}")
-    else:
-        details.append("baseline.scores type=None")
-
-    if candidate.get("scores_keys") is not None:
-        details.append(f"candidate.scores keys={candidate.get('scores_keys')!r}")
-    else:
-        details.append("candidate.scores type=None")
-
-    if baseline.get("primary_metric") is not None:
-        details.append(
-            f"baseline.{baseline.get('primary_metric')}={baseline.get('metric_value')!r}"
-        )
-    if candidate.get("primary_metric") is not None:
-        details.append(
-            f"candidate.{candidate.get('primary_metric')}={candidate.get('metric_value')!r}"
-        )
-
-    if "replicate_key" in context:
-        details.append(f"replicate_key={context['replicate_key']}")
-
-    return "; ".join(details)

--- a/insideLLMs/cli/commands/_run_common.py
+++ b/insideLLMs/cli/commands/_run_common.py
@@ -7,16 +7,47 @@ This module centralizes common command behaviors so `insidellms run` and
 from __future__ import annotations
 
 import argparse
+import inspect
+from inspect import Parameter
 from pathlib import Path
 from typing import Any
 
 import insideLLMs.experiment_tracking as experiment_tracking
 
+from insideLLMs.models.base import Model
+from insideLLMs.registry import Registry, model_registry
+from insideLLMs.runtime._artifact_utils import _default_run_root
+
 from .._output import print_warning
 
 
+def _filter_factory_kwargs(registry: Registry[Any], name: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Keep only kwargs accepted by the registered factory signature."""
+    factory = registry.get_factory(name)
+    if not callable(factory):
+        return kwargs
+    try:
+        sig = inspect.signature(factory)
+    except (TypeError, ValueError):
+        return kwargs
+    if any(param.kind == Parameter.VAR_KEYWORD for param in sig.parameters.values()):
+        return kwargs
+    allowed = set(sig.parameters)
+    return {key: value for key, value in kwargs.items() if key in allowed}
+
+
+def resolve_registered_model(name: str, **kwargs: Any) -> Model:
+    """Instantiate a registered model with optional override kwargs."""
+    filtered = _filter_factory_kwargs(model_registry, name, kwargs)
+    return model_registry.get(name, **filtered)
+
+
 def resolve_harness_output_dir(
-    args: argparse.Namespace, config: dict[str, Any], resolved_run_id: str
+    args: argparse.Namespace,
+    config: dict[str, Any],
+    resolved_run_id: str,
+    *,
+    config_path: Path | None = None,
 ) -> Path:
     """Resolve the effective output directory for harness artifacts.
 
@@ -24,21 +55,32 @@ def resolve_harness_output_dir(
         args: Parsed CLI arguments from `insidellms harness`.
         config: Loaded harness config dict.
         resolved_run_id: Final run identifier for this execution.
+        config_path: Source config path; used to resolve relative ``output_dir``.
 
     Returns:
         Absolute output path where harness artifacts should be written.
     """
 
-    effective_run_root = Path(args.run_root).expanduser().absolute() if args.run_root else None
-    config_default_dir = Path(config.get("output_dir", "results")).expanduser().absolute()
+    default_run_root = _default_run_root().expanduser().absolute()
+    effective_run_root = (
+        Path(args.run_root).expanduser().absolute() if args.run_root else default_run_root
+    )
 
     if args.run_dir:
         return Path(args.run_dir).expanduser().absolute()
     if args.output_dir:
         return Path(args.output_dir).expanduser().absolute()
-    if effective_run_root is not None:
+    if args.run_root:
         return effective_run_root / resolved_run_id
-    return config_default_dir
+
+    config_output_dir = config.get("output_dir")
+    if config_output_dir:
+        raw = Path(str(config_output_dir)).expanduser()
+        if not raw.is_absolute() and config_path is not None:
+            return (config_path.parent / raw).absolute()
+        return raw.absolute()
+
+    return effective_run_root / resolved_run_id
 
 
 def create_tracker(

--- a/insideLLMs/cli/commands/benchmark.py
+++ b/insideLLMs/cli/commands/benchmark.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from insideLLMs.exceptions import ProbeExecutionError
-from insideLLMs.registry import ensure_builtins_registered, model_registry, probe_registry
+from insideLLMs.registry import ensure_builtins_registered, probe_registry
 
 from .._output import (
     Colors,
@@ -20,6 +20,7 @@ from .._output import (
     print_success,
     print_warning,
 )
+from ._run_common import resolve_registered_model
 
 
 def cmd_benchmark(args: argparse.Namespace) -> int:
@@ -65,10 +66,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
             print_subheader(f"Model: {model_name}")
 
             try:
-                model_or_factory = model_registry.get(model_name)
-                model = (
-                    model_or_factory() if isinstance(model_or_factory, type) else model_or_factory
-                )
+                model = resolve_registered_model(model_name)
             except Exception as e:
                 print_warning(f"Could not load model {model_name}: {e}")
                 continue
@@ -77,12 +75,7 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
                 print(f"  Running probe: {colorize(probe_name, Colors.GREEN)}")
 
                 try:
-                    probe_or_factory = probe_registry.get(probe_name)
-                    probe = (
-                        probe_or_factory()
-                        if isinstance(probe_or_factory, type)
-                        else probe_or_factory
-                    )
+                    probe = probe_registry.get(probe_name)
                 except Exception as e:
                     print_warning(f"  Could not load probe {probe_name}: {e}")
                     continue
@@ -96,15 +89,22 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
                 progress = ProgressBar(len(inputs), prefix=f"  {probe_name}")
 
                 probe_results = []
+                error_count = 0
                 for i, inp in enumerate(inputs):
                     try:
                         result = runner.run_single(inp)
                         probe_results.append(result)
-                    except (ProbeExecutionError, RuntimeError):
-                        pass
+                    except (ProbeExecutionError, RuntimeError) as exc:
+                        error_count += 1
+                        print_warning(f"  Example {i + 1} failed: {exc}")
                     progress.update(i + 1)
 
                 progress.finish()
+
+                if error_count:
+                    print_warning(
+                        f"  {error_count} example(s) failed for {model_name}/{probe_name}"
+                    )
 
                 success_count = sum(
                     1

--- a/insideLLMs/cli/commands/compare.py
+++ b/insideLLMs/cli/commands/compare.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from insideLLMs.registry import ensure_builtins_registered, model_registry
+from insideLLMs.registry import ensure_builtins_registered
 
 from .._output import (
     Colors,
@@ -19,6 +19,7 @@ from .._output import (
     print_warning,
 )
 from .._record_utils import _json_default
+from ._run_common import resolve_registered_model
 
 
 def cmd_compare(args: argparse.Namespace) -> int:
@@ -91,10 +92,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         model_instances: dict[str, Any] = {}
         for model_name in models:
             try:
-                model_or_factory = model_registry.get(model_name)
-                model_instances[model_name] = (
-                    model_or_factory() if isinstance(model_or_factory, type) else model_or_factory
-                )
+                model_instances[model_name] = resolve_registered_model(model_name)
             except Exception as e:
                 model_instances[model_name] = None
                 print_warning(f"Could not load model '{model_name}': {e}")

--- a/insideLLMs/cli/commands/export.py
+++ b/insideLLMs/cli/commands/export.py
@@ -94,9 +94,11 @@ def cmd_export(args: argparse.Namespace) -> int:
                     f.write("\n".join(lines))
 
         elif args.format == "jsonl":
+            from insideLLMs._serialization import stable_json_dumps
+
             with open(output_path, "w", encoding="utf-8") as f:
                 for r in results:
-                    f.write(json.dumps(r, default=str) + "\n")
+                    f.write(stable_json_dumps(r) + "\n")
 
         if getattr(args, "encrypt", False):
             key_env = getattr(args, "encryption_key_env", "INSIDELLMS_ENCRYPTION_KEY")

--- a/insideLLMs/cli/commands/generate_suite.py
+++ b/insideLLMs/cli/commands/generate_suite.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from insideLLMs.contrib.synthesis import generate_test_dataset
-from insideLLMs.registry import ensure_builtins_registered, model_registry
+from insideLLMs.registry import ensure_builtins_registered
 
 from .._output import (
     Colors,
@@ -20,6 +20,7 @@ from .._output import (
     print_subheader,
     print_success,
 )
+from ._run_common import resolve_registered_model
 
 
 def _default_seed_prompts(target: str) -> list[str]:
@@ -89,12 +90,7 @@ def cmd_generate_suite(args: argparse.Namespace) -> int:
         seed_prompts = _default_seed_prompts(args.target)
 
     try:
-        model_or_factory = model_registry.get(args.model)
-        model = (
-            model_or_factory(**model_args)
-            if isinstance(model_or_factory, type)
-            else model_or_factory
-        )
+        model = resolve_registered_model(args.model, **model_args)
     except Exception as exc:
         print_error(f"Could not initialize model '{args.model}': {exc}")
         return 1

--- a/insideLLMs/cli/commands/harness.py
+++ b/insideLLMs/cli/commands/harness.py
@@ -350,9 +350,16 @@ def cmd_harness(args: argparse.Namespace) -> int:
             strict_serialization=args.strict_serialization,
         )
 
-        # Precompute output_dir for tracking. Must match the precedence used later when emitting
-        # standardized run artifacts.
-        output_dir = resolve_harness_output_dir(args, loaded_config, resolved_run_id)
+        output_dir = resolve_harness_output_dir(
+            args,
+            loaded_config,
+            resolved_run_id,
+            config_path=run_config_path,
+        )
+        effective_run_root = Path(args.run_root).expanduser().absolute() if args.run_root else None
+
+        _prepare_run_dir(output_dir, overwrite=bool(args.overwrite), run_root=effective_run_root)
+        _ensure_run_sentinel(output_dir)
 
         tracker = create_tracker(
             backend=args.track,
@@ -394,6 +401,8 @@ def cmd_harness(args: argparse.Namespace) -> int:
                 deterministic_artifacts_override=args.deterministic_artifacts,
             )
 
+        result_config = result.get("config")
+        config_for_output_dir = result_config if isinstance(result_config, dict) else loaded_config
         if args.run_id:
             resolved_run_id = args.run_id
         else:
@@ -410,14 +419,12 @@ def cmd_harness(args: argparse.Namespace) -> int:
                         "strict_serialization requires JSON-stable values in the resolved harness config."
                     ) from exc
 
-        result_config = result.get("config")
-        config_for_output_dir = result_config if isinstance(result_config, dict) else {}
-        output_dir = resolve_harness_output_dir(args, config_for_output_dir, resolved_run_id)
-        effective_run_root = Path(args.run_root).expanduser().absolute() if args.run_root else None
-
-        # Prepare run dir with the same safety policy as `insidellms run`.
-        _prepare_run_dir(output_dir, overwrite=bool(args.overwrite), run_root=effective_run_root)
-        _ensure_run_sentinel(output_dir)
+        output_dir = resolve_harness_output_dir(
+            args,
+            config_for_output_dir,
+            resolved_run_id,
+            config_path=run_config_path,
+        )
 
         # Write resolved config snapshot for reproducibility.
         _atomic_write_yaml(

--- a/insideLLMs/cli/commands/init_cmd.py
+++ b/insideLLMs/cli/commands/init_cmd.py
@@ -16,6 +16,16 @@ from .._output import (
 )
 
 
+def _init_uses_defaults(args: argparse.Namespace) -> bool:
+    """Return True when init was invoked with parser defaults only."""
+    return (
+        getattr(args, "output", "experiment.yaml") == "experiment.yaml"
+        and getattr(args, "model", "dummy") == "dummy"
+        and getattr(args, "probe", "logic") == "logic"
+        and getattr(args, "template", "basic") == "basic"
+    )
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Execute the init command."""
     import yaml
@@ -27,15 +37,8 @@ def cmd_init(args: argparse.Namespace) -> int:
     template = args.template
     output = args.output
 
-    # Check if we should go interactive
-    # Heuristic: --interactive flag OR (no other flags passed AND in a TTY AND not quiet)
-    try:
-        init_idx = sys.argv.index("init")
-        args_after_init = len(sys.argv) - 1 - init_idx
-    except ValueError:
-        args_after_init = 0
-
-    if args.interactive or (args_after_init == 0 and sys.stdin.isatty() and not args.quiet):
+    # Interactive when explicitly requested, or defaults-only invocation in a TTY.
+    if args.interactive or (_init_uses_defaults(args) and sys.stdin.isatty() and not args.quiet):
         try:
             print("  Welcome to the interactive experiment setup!")
             print("  Press Enter to use [defaults].\n")

--- a/insideLLMs/cli/commands/interactive.py
+++ b/insideLLMs/cli/commands/interactive.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from insideLLMs.registry import ensure_builtins_registered, model_registry, probe_registry
+from insideLLMs.registry import ensure_builtins_registered, probe_registry
 
 from .._output import (
     Colors,
@@ -20,6 +20,7 @@ from .._output import (
     print_success,
     print_warning,
 )
+from ._run_common import resolve_registered_model
 
 
 def cmd_interactive(args: argparse.Namespace) -> int:
@@ -31,8 +32,7 @@ def cmd_interactive(args: argparse.Namespace) -> int:
     print_info("Type 'help' for commands, 'quit' to exit")
 
     try:
-        model_or_factory = model_registry.get(args.model)
-        model = model_or_factory() if isinstance(model_or_factory, type) else model_or_factory
+        model = resolve_registered_model(args.model)
     except Exception as e:
         print_error(f"Could not load model: {e}")
         return 1
@@ -94,10 +94,7 @@ def cmd_interactive(args: argparse.Namespace) -> int:
         elif prompt.lower().startswith("model "):
             new_model = prompt[6:].strip()
             try:
-                model_or_factory = model_registry.get(new_model)
-                model = (
-                    model_or_factory() if isinstance(model_or_factory, type) else model_or_factory
-                )
+                model = resolve_registered_model(new_model)
                 print_success(f"Switched to model: {new_model}")
             except Exception as e:
                 print_error(f"Could not load model: {e}")
@@ -107,8 +104,7 @@ def cmd_interactive(args: argparse.Namespace) -> int:
                 print_warning("No previous response to evaluate. Send a prompt first.")
                 continue
             try:
-                probe_factory = probe_registry.get(probe_name)
-                probe = probe_factory() if isinstance(probe_factory, type) else probe_factory
+                probe = probe_registry.get(probe_name)
                 print_subheader(f"Probe: {probe.name}")
                 result = probe.run(model, last_prompt)
                 if isinstance(result, dict):

--- a/insideLLMs/cli/commands/quicktest.py
+++ b/insideLLMs/cli/commands/quicktest.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import time
 
-from insideLLMs.registry import ensure_builtins_registered, model_registry, probe_registry
+from insideLLMs.registry import ensure_builtins_registered, probe_registry
 
 from .._output import (
     Colors,
@@ -16,6 +16,7 @@ from .._output import (
     print_key_value,
     print_subheader,
 )
+from ._run_common import resolve_registered_model
 
 
 def cmd_quicktest(args: argparse.Namespace) -> int:
@@ -27,26 +28,22 @@ def cmd_quicktest(args: argparse.Namespace) -> int:
     print_key_value("Prompt", args.prompt[:50] + "..." if len(args.prompt) > 50 else args.prompt)
 
     try:
-        # Parse model args
         model_args = json.loads(args.model_args)
-        model_args["temperature"] = args.temperature
-        model_args["max_tokens"] = args.max_tokens
+        init_kwargs = dict(model_args)
+        init_kwargs.pop("temperature", None)
+        init_kwargs.pop("max_tokens", None)
 
-        # Get model from registry - it may be a class or instance
-        model_or_factory = model_registry.get(args.model)
+        model = resolve_registered_model(args.model, **init_kwargs)
 
-        # If it's a class, instantiate it; if it's already an instance, use it
-        if isinstance(model_or_factory, type):
-            model = model_or_factory(**model_args)
-        else:
-            model = model_or_factory
-
-        # Generate response
         spinner = Spinner("Generating response")
         start_time = time.time()
         spinner.spin()
 
-        response = model.generate(args.prompt)
+        response = model.generate(
+            args.prompt,
+            temperature=args.temperature,
+            max_tokens=args.max_tokens,
+        )
         elapsed = time.time() - start_time
         spinner.stop(success=True)
 
@@ -57,12 +54,15 @@ def cmd_quicktest(args: argparse.Namespace) -> int:
         print_key_value("Latency", f"{elapsed * 1000:.1f}ms")
         print_key_value("Response length", f"{len(response)} characters")
 
-        # Apply probe if specified
         if args.probe:
             print_subheader(f"Probe: {args.probe}")
-            probe_factory = probe_registry.get(args.probe)
-            probe_factory()
-            # Note: Probe evaluation would go here
+            probe = probe_registry.get(args.probe)
+            probe_result = probe.run(model, args.prompt)
+            if isinstance(probe_result, dict):
+                for key, value in probe_result.items():
+                    print_key_value(str(key), str(value))
+            else:
+                print_key_value("Result", str(probe_result))
             print_info(
                 f"Probe '{args.probe}' applied (detailed scoring available in full experiments)"
             )

--- a/insideLLMs/cli/commands/run.py
+++ b/insideLLMs/cli/commands/run.py
@@ -90,11 +90,14 @@ def cmd_run(args: argparse.Namespace) -> int:
         )
 
         if args.use_async:
-            print_info(f"Using async execution with concurrency={args.concurrency}")
+            concurrency_label = args.concurrency if args.concurrency is not None else "config/default"
+            print_info(f"Using async execution with concurrency={concurrency_label}")
             results = asyncio.run(
                 run_experiment_from_config_async(
                     config_path,
                     concurrency=args.concurrency,
+                    timeout=getattr(args, "timeout", None),
+                    stop_on_error=bool(getattr(args, "stop_on_error", False)) or None,
                     progress_callback=progress_callback if args.verbose else None,
                     validate_output=args.validate_output,
                     schema_version=args.schema_version,
@@ -124,6 +127,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 resume=bool(args.resume),
                 strict_serialization=args.strict_serialization,
                 deterministic_artifacts=args.deterministic_artifacts,
+                stop_on_error=bool(getattr(args, "stop_on_error", False)) or None,
             )
 
         elapsed = time.time() - start_time

--- a/insideLLMs/contrib/diffing.py
+++ b/insideLLMs/contrib/diffing.py
@@ -1,11 +1,6 @@
-"""Public diffing facade.
+"""Public diffing facade (contrib re-export)."""
 
-This module provides a narrow import surface for deterministic behavioral diff
-computation and snapshot-interactive helpers without requiring broad
-``insideLLMs.runtime`` imports.
-"""
-
-from insideLLMs.runtime.diffing import (
+from insideLLMs.diffing import (
     DiffComputation,
     DiffGatePolicy,
     DiffJudgeComputation,

--- a/insideLLMs/registry.py
+++ b/insideLLMs/registry.py
@@ -1716,9 +1716,12 @@ def ensure_builtins_registered() -> None:
         try:
             register_builtins()
             _builtins_registered = True
-        except ImportError:
-            # Some dependencies might not be installed
-            pass
+        except ImportError as exc:
+            warnings.warn(
+                f"Builtin registration failed ({exc}). Some models or probes may be unavailable.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     if _builtins_registered and not _plugins_loaded:
         load_entrypoint_plugins()

--- a/insideLLMs/runtime/_async_runner.py
+++ b/insideLLMs/runtime/_async_runner.py
@@ -456,6 +456,12 @@ class AsyncProbeRunner(_RunnerBase):
             nonlocal completed, stop_error
             async with semaphore:
                 if stop_event.is_set():
+                    results[index] = {
+                        "input": item,
+                        "output": None,
+                        "status": "skipped",
+                        "metadata": {"skipped": True, "reason": "stop_on_error"},
+                    }
                     return
                 try:
                     loop = asyncio.get_running_loop()

--- a/insideLLMs/runtime/_base.py
+++ b/insideLLMs/runtime/_base.py
@@ -273,7 +273,7 @@ class _RunnerBase:
             >>> if runner.error_count > 0:
             ...     print(f"Encountered {runner.error_count} errors")
         """
-        return sum(1 for r in self._results if r.get("status") == "error")
+        return sum(1 for r in self._results if r.get("status") in {"error", "timeout"})
 
 
 __all__ = [

--- a/insideLLMs/runtime/_high_level.py
+++ b/insideLLMs/runtime/_high_level.py
@@ -55,6 +55,12 @@ from insideLLMs.types import (
 logger = logging.getLogger(__name__)
 
 
+def _runner_settings_from_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Extract optional ``runner:`` block from a loaded experiment config."""
+    runner = config.get("runner")
+    return dict(runner) if isinstance(runner, dict) else {}
+
+
 def run_probe(
     model: Model,
     probe: Probe,
@@ -175,6 +181,7 @@ def run_experiment_from_config(
     deterministic_artifacts: Optional[bool] = None,
     use_probe_batch: bool = False,
     batch_workers: Optional[int] = None,
+    stop_on_error: Optional[bool] = None,
     return_experiment: bool = False,
 ) -> Union[list[dict[str, Any]], ExperimentResult]:
     """Run an experiment defined in a YAML or JSON configuration file.
@@ -227,6 +234,7 @@ def run_experiment_from_config(
     config_path = Path(config_path)
     config = load_config(config_path)
     base_dir = config_path.parent
+    runner_settings = _runner_settings_from_config(config)
 
     config_snapshot = _build_resolved_config_snapshot(config, base_dir)
     strict_serialization, deterministic_artifacts = _resolve_determinism_options(
@@ -253,6 +261,15 @@ def run_experiment_from_config(
     probe_kwargs.update(_extract_probe_kwargs_from_config(config_snapshot.get("probe")))
 
     runner = ProbeRunner(model, probe)
+    effective_stop_on_error = (
+        stop_on_error
+        if stop_on_error is not None
+        else runner_settings.get("stop_on_error")
+    )
+    effective_use_probe_batch = use_probe_batch or bool(runner_settings.get("use_probe_batch"))
+    effective_batch_workers = (
+        batch_workers if batch_workers is not None else runner_settings.get("batch_workers")
+    )
     return runner.run(
         dataset,
         progress_callback=progress_callback,
@@ -269,8 +286,9 @@ def run_experiment_from_config(
         resume=resume,
         strict_serialization=strict_serialization,
         deterministic_artifacts=deterministic_artifacts,
-        use_probe_batch=use_probe_batch,
-        batch_workers=batch_workers,
+        use_probe_batch=effective_use_probe_batch,
+        batch_workers=effective_batch_workers,
+        stop_on_error=effective_stop_on_error,
         return_experiment=return_experiment,
         **probe_kwargs,
     )
@@ -320,6 +338,7 @@ def run_harness_from_config(
     config_path = Path(config_path)
     config = load_config(config_path)
     base_dir = config_path.parent
+    runner_settings = _runner_settings_from_config(config)
 
     config_snapshot = _build_resolved_config_snapshot(config, base_dir)
     strict_serialization, deterministic_artifacts = _resolve_determinism_options(
@@ -429,7 +448,7 @@ def run_harness_from_config(
         }
 
     for model_idx, model_config in enumerate(models_config):
-        model = _create_model_from_config(model_config)
+        model = _create_model_from_config(model_config, prefer_async_pipeline=True)
         model_info = _coerce_model_info(model)
         model_spec = _model_spec_for_harness(model, model_config)
 
@@ -578,7 +597,7 @@ def run_harness_from_config(
 async def run_experiment_from_config_async(
     config_path: Union[str, Path],
     *,
-    concurrency: int = 5,
+    concurrency: Optional[int] = None,
     progress_callback: Optional[Callable[[int, int], None]] = None,
     validate_output: bool = False,
     schema_version: str = DEFAULT_SCHEMA_VERSION,
@@ -593,6 +612,8 @@ async def run_experiment_from_config_async(
     deterministic_artifacts: Optional[bool] = None,
     use_probe_batch: bool = False,
     batch_workers: Optional[int] = None,
+    stop_on_error: Optional[bool] = None,
+    timeout: Optional[float] = None,
     return_experiment: bool = False,
 ) -> Union[list[dict[str, Any]], ExperimentResult]:
     """Run an experiment asynchronously from a configuration file.
@@ -647,6 +668,7 @@ async def run_experiment_from_config_async(
     config_path = Path(config_path)
     config = load_config(config_path)
     base_dir = config_path.parent
+    runner_settings = _runner_settings_from_config(config)
 
     config_snapshot = _build_resolved_config_snapshot(config, base_dir)
     strict_serialization, deterministic_artifacts = _resolve_determinism_options(
@@ -665,7 +687,7 @@ async def run_experiment_from_config_async(
             "strict_serialization requires JSON-stable values in the resolved config snapshot."
         ) from exc
 
-    model = _create_model_from_config(config["model"])
+    model = _create_model_from_config(config["model"], prefer_async_pipeline=True)
     probe = _create_probe_from_config(config["probe"])
     dataset = _load_dataset_from_config(config["dataset"], base_dir)
 
@@ -673,9 +695,22 @@ async def run_experiment_from_config_async(
     probe_kwargs.update(_extract_probe_kwargs_from_config(config_snapshot.get("probe")))
 
     runner = AsyncProbeRunner(model, probe)
+    effective_concurrency = (
+        concurrency if concurrency is not None else int(runner_settings.get("concurrency", 5))
+    )
+    effective_timeout = timeout if timeout is not None else runner_settings.get("timeout")
+    effective_stop_on_error = (
+        stop_on_error
+        if stop_on_error is not None
+        else runner_settings.get("stop_on_error")
+    )
+    effective_use_probe_batch = use_probe_batch or bool(runner_settings.get("use_probe_batch"))
+    effective_batch_workers = (
+        batch_workers if batch_workers is not None else runner_settings.get("batch_workers")
+    )
     return await runner.run(
         dataset,
-        concurrency=concurrency,
+        concurrency=effective_concurrency,
         progress_callback=progress_callback,
         validate_output=validate_output,
         schema_version=schema_version,
@@ -690,8 +725,10 @@ async def run_experiment_from_config_async(
         resume=resume,
         strict_serialization=strict_serialization,
         deterministic_artifacts=deterministic_artifacts,
-        use_probe_batch=use_probe_batch,
-        batch_workers=batch_workers,
+        use_probe_batch=effective_use_probe_batch,
+        batch_workers=effective_batch_workers,
+        stop_on_error=effective_stop_on_error,
+        timeout=float(effective_timeout) if effective_timeout is not None else None,
         return_experiment=return_experiment,
         **probe_kwargs,
     )

--- a/insideLLMs/runtime/_result_utils.py
+++ b/insideLLMs/runtime/_result_utils.py
@@ -570,7 +570,7 @@ def _result_dict_from_record(
         "output": record.get("output"),
         "latency_ms": record.get("latency_ms"),
         "status": record.get("status"),
-        "metadata": {},
+        "metadata": dict(record["metadata"]) if isinstance(record.get("metadata"), dict) else {},
     }
     if record.get("error") is not None:
         payload["error"] = record.get("error")

--- a/insideLLMs/runtime/_sync_runner.py
+++ b/insideLLMs/runtime/_sync_runner.py
@@ -439,7 +439,7 @@ class ProbeRunner(_RunnerBase):
                             schema_version=schema_version,
                             error_type=error_type,
                         )
-                        result_obj["latency_ms"] = None
+                        result_obj["latency_ms"] = probe_result.latency_ms
                         results[i] = result_obj
 
                         if emit_run_artifacts and records_fp is not None:
@@ -457,7 +457,7 @@ class ProbeRunner(_RunnerBase):
                                 dataset=dataset_spec,
                                 item=prompt_set[i],
                                 output=probe_result.output,
-                                latency_ms=None,
+                                latency_ms=probe_result.latency_ms,
                                 store_messages=store_messages,
                                 index=i,
                                 status=_normalize_status(probe_result.status),
@@ -504,6 +504,9 @@ class ProbeRunner(_RunnerBase):
                                     ],
                                 )
 
+                        if stop_error is not None:
+                            break
+
                     if stop_error is not None:
                         raise stop_error
             else:
@@ -546,7 +549,7 @@ class ProbeRunner(_RunnerBase):
                                 dataset=dataset_spec,
                                 item=item,
                                 output=output,
-                                latency_ms=None,
+                                latency_ms=probe_result.latency_ms,
                                 store_messages=store_messages,
                                 index=i,
                                 status="success",
@@ -606,7 +609,7 @@ class ProbeRunner(_RunnerBase):
                                 dataset=dataset_spec,
                                 item=item,
                                 output=None,
-                                latency_ms=None,
+                                latency_ms=probe_result.latency_ms,
                                 store_messages=store_messages,
                                 index=i,
                                 status="timeout" if is_timeout else "error",

--- a/insideLLMs/runtime/diffing.py
+++ b/insideLLMs/runtime/diffing.py
@@ -7,6 +7,7 @@ and library users can compose on top of the same core behavior.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping
 
@@ -40,6 +41,7 @@ class DiffComputation:
         """Whether any behavioral/trace differences are present."""
         return bool(
             self.regressions
+            or self.improvements
             or self.changes
             or self.only_baseline
             or self.only_candidate
@@ -116,7 +118,10 @@ def _record_label(record: dict[str, Any]) -> tuple[str, str, str]:
         model_label = str(model_name)
 
     probe_name = harness.get("probe_name") or probe_spec.get("probe_id") or "probe"
-    example_id = record.get("example_id") or harness.get("example_index") or "0"
+    replicate_key = custom.get("replicate_key")
+    example_id = (
+        replicate_key or record.get("example_id") or harness.get("example_index") or "0"
+    )
     return (str(model_label), str(probe_name), str(example_id))
 
 
@@ -155,25 +160,64 @@ def _strip_volatile_keys(value: Any, ignore_keys: set[str]) -> Any:
     return value
 
 
+def _is_numeric_score(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 def _output_fingerprint(record: dict[str, Any], ignore_keys: set[str] | None = None) -> str | None:
+    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
+    override = custom.get("output_fingerprint")
     output = record.get("output")
     if ignore_keys:
-        custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-        override = custom.get("output_fingerprint")
-        if output is None and isinstance(override, str):
+        if isinstance(override, str) and output is None:
             return override
         if output is None:
             return None
         sanitized = _strip_volatile_keys(output, ignore_keys)
         return _fingerprint_value(sanitized)
 
-    custom = record.get("custom") if isinstance(record.get("custom"), dict) else {}
-    override = custom.get("output_fingerprint")
     if isinstance(override, str):
         return override
     if output is None:
         return None
     return _fingerprint_value(output)
+
+
+def _output_text_fingerprint(
+    record: dict[str, Any],
+    ignore_keys: set[str] | None = None,
+) -> str | None:
+    """Fingerprint text output, applying ignore_keys when JSON-encoded."""
+    text = _output_text(record)
+    if text is None:
+        return None
+    if not ignore_keys:
+        return text
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return text
+    sanitized = _strip_volatile_keys(parsed, ignore_keys)
+    return _fingerprint_value(sanitized)
+
+
+def _outputs_differ(
+    record_a: dict[str, Any],
+    record_b: dict[str, Any],
+    ignore_keys: set[str] | None,
+) -> bool:
+    text_a = _output_text(record_a)
+    text_b = _output_text(record_b)
+    if text_a is not None or text_b is not None:
+        if ignore_keys:
+            return _output_text_fingerprint(record_a, ignore_keys) != _output_text_fingerprint(
+                record_b, ignore_keys
+            )
+        return text_a != text_b
+
+    fingerprint_a = _output_fingerprint(record_a, ignore_keys=ignore_keys)
+    fingerprint_b = _output_fingerprint(record_b, ignore_keys=ignore_keys)
+    return fingerprint_a != fingerprint_b
 
 
 def _output_summary(record: dict[str, Any], ignore_keys: set[str] | None) -> dict[str, Any] | None:
@@ -335,11 +379,19 @@ def _trajectory_summary(record: dict[str, Any]) -> dict[str, Any] | None:
 def _primary_score(record: dict[str, Any]) -> tuple[str | None, float | None]:
     scores = record.get("scores") if isinstance(record.get("scores"), dict) else {}
     metric = record.get("primary_metric")
-    if metric and metric in scores and isinstance(scores[metric], (int, float)):
+    if metric and metric in scores and _is_numeric_score(scores[metric]):
         return str(metric), float(scores[metric])
-    if "score" in scores and isinstance(scores["score"], (int, float)):
+    if not metric and "score" in scores and _is_numeric_score(scores["score"]):
         return "score", float(scores["score"])
     return None, None
+
+
+def _scores_comparable(record_a: dict[str, Any], record_b: dict[str, Any]) -> bool:
+    primary_a = record_a.get("primary_metric")
+    primary_b = record_b.get("primary_metric")
+    if primary_a and primary_b and primary_a != primary_b:
+        return False
+    return True
 
 
 def _metric_mismatch_reason(record_a: dict[str, Any], record_b: dict[str, Any]) -> str | None:
@@ -365,7 +417,7 @@ def _metric_mismatch_reason(record_a: dict[str, Any], record_b: dict[str, Any]) 
 
     value_a = scores_a.get(primary_a)
     value_b = scores_b.get(primary_b)
-    if not isinstance(value_a, (int, float)) or not isinstance(value_b, (int, float)):
+    if not _is_numeric_score(value_a) or not _is_numeric_score(value_b):
         return "non_numeric_metric"
 
     return "type_mismatch"
@@ -561,6 +613,7 @@ def build_diff_computation(
         summary_a = _record_summary(record_a, ignore_keys)
         summary_b = _record_summary(record_b, ignore_keys)
 
+        status_handled = False
         if status_a == "success" and status_b != "success":
             regressions.append((*label, f"status {status_a} -> {status_b}"))
             regressions_json.append(
@@ -572,8 +625,8 @@ def build_diff_computation(
                     "candidate": summary_b,
                 }
             )
-            continue
-        if status_a != "success" and status_b == "success":
+            status_handled = True
+        elif status_a != "success" and status_b == "success":
             improvements.append((*label, f"status {status_a} -> {status_b}"))
             improvements_json.append(
                 {
@@ -584,10 +637,24 @@ def build_diff_computation(
                     "candidate": summary_b,
                 }
             )
-            continue
+            status_handled = True
 
         metrics_compared = False
-        if score_a is not None and score_b is not None and score_name_a == score_name_b:
+        if not _scores_comparable(record_a, record_b):
+            reason = "primary_metric_mismatch"
+            detail = _metric_mismatch_details(record_a, record_b)
+            changes.append((*label, f"metrics not comparable:{reason}; {detail}"))
+            changes_json.append(
+                {
+                    **identity,
+                    "kind": "metrics_not_comparable",
+                    "reason": reason,
+                    "baseline": summary_a,
+                    "candidate": summary_b,
+                    "details": _metric_mismatch_context(record_a, record_b),
+                }
+            )
+        elif score_a is not None and score_b is not None and score_name_a == score_name_b:
             delta = score_b - score_a
             metrics_compared = True
             if delta < 0:
@@ -604,8 +671,7 @@ def build_diff_computation(
                         "delta": delta,
                     }
                 )
-                continue
-            if delta > 0:
+            elif delta > 0:
                 improvements.append(
                     (*label, f"{score_name_a} {score_a:.4f} -> {score_b:.4f} (delta +{delta:.4f})")
                 )
@@ -620,7 +686,9 @@ def build_diff_computation(
                     }
                 )
 
-        if not metrics_compared and (score_a is not None or score_b is not None):
+        if not metrics_compared and _scores_comparable(record_a, record_b) and (
+            score_a is not None or score_b is not None
+        ):
             reason = _metric_mismatch_reason(record_a, record_b) or "type_mismatch"
             detail = _metric_mismatch_details(record_a, record_b)
             changes.append((*label, f"metrics not comparable:{reason}; {detail}"))
@@ -662,40 +730,28 @@ def build_diff_computation(
                         }
                     )
 
-        output_a = _output_text(record_a)
-        output_b = _output_text(record_b)
-        if output_a is not None or output_b is not None:
-            if output_a != output_b:
-                changes.append((*label, "output changed"))
-                changes_json.append(
-                    {
-                        **identity,
-                        "kind": "output_changed",
-                        "baseline": summary_a,
-                        "candidate": summary_b,
-                    }
-                )
-        else:
+        if _outputs_differ(record_a, record_b, ignore_keys):
             fingerprint_a = _output_fingerprint(record_a, ignore_keys=ignore_keys)
             fingerprint_b = _output_fingerprint(record_b, ignore_keys=ignore_keys)
-            if fingerprint_a != fingerprint_b:
-                if fingerprint_a and fingerprint_b:
-                    changes.append(
-                        (*label, f"output fingerprint {fingerprint_a} -> {fingerprint_b}")
-                    )
-                else:
-                    changes.append((*label, "output changed (structured)"))
-                changes_json.append(
-                    {
-                        **identity,
-                        "kind": "output_changed",
-                        "baseline": summary_a,
-                        "candidate": summary_b,
-                        "baseline_fingerprint": fingerprint_a,
-                        "candidate_fingerprint": fingerprint_b,
-                    }
-                )
-        if status_a != status_b:
+            text_a = _output_text(record_a)
+            text_b = _output_text(record_b)
+            if text_a is not None or text_b is not None:
+                changes.append((*label, "output changed"))
+            elif fingerprint_a and fingerprint_b:
+                changes.append((*label, f"output fingerprint {fingerprint_a} -> {fingerprint_b}"))
+            else:
+                changes.append((*label, "output changed (structured)"))
+            changes_json.append(
+                {
+                    **identity,
+                    "kind": "output_changed",
+                    "baseline": summary_a,
+                    "candidate": summary_b,
+                    "baseline_fingerprint": fingerprint_a,
+                    "candidate_fingerprint": fingerprint_b,
+                }
+            )
+        if not status_handled and status_a != status_b:
             changes.append((*label, f"status {status_a} -> {status_b}"))
             changes_json.append(
                 {

--- a/insideLLMs/runtime/diffing_interactive.py
+++ b/insideLLMs/runtime/diffing_interactive.py
@@ -63,10 +63,21 @@ def build_interactive_review_lines(
 ) -> list[str]:
     """Build a concise interactive review view for snapshot acceptance."""
     regressions = diff_report.get("regressions", [])
+    improvements = diff_report.get("improvements", [])
     changes = diff_report.get("changes", [])
+    trace_drifts = diff_report.get("trace_drifts", [])
+    trace_violation_increases = diff_report.get("trace_violation_increases", [])
+    trajectory_drifts = diff_report.get("trajectory_drifts", [])
     only_baseline = diff_report.get("only_baseline", [])
     only_candidate = diff_report.get("only_candidate", [])
-    review_items = [*regressions, *changes]
+    review_items = [
+        *regressions,
+        *improvements,
+        *changes,
+        *trace_drifts,
+        *trace_violation_increases,
+        *trajectory_drifts,
+    ]
     dim = dim_text or (lambda s: s)
 
     lines: list[str] = []

--- a/insideLLMs/runtime/pipeline.py
+++ b/insideLLMs/runtime/pipeline.py
@@ -239,6 +239,7 @@ insideLLMs.exceptions : Exception classes used by middleware
 """
 
 import asyncio
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator
@@ -1953,6 +1954,7 @@ class CacheMiddleware(Middleware):
         self.ttl_seconds = ttl_seconds
         self.hits = 0
         self.misses = 0
+        self._sync_lock = threading.Lock()
 
     def _cache_key(self, prompt: str, **kwargs: Any) -> str:
         """Generate a deterministic cache key from prompt and parameters.
@@ -2074,18 +2076,17 @@ class CacheMiddleware(Middleware):
         """
         key = self._cache_key(prompt, **kwargs)
 
-        # Check cache
-        cached = self.cache.pop(key, None)
-        if cached is not None:
-            response, timestamp = cached
-            if not self._is_expired(timestamp):
-                self.hits += 1
-                # True LRU: move most-recently-used key to the end.
-                self.cache[key] = (response, timestamp)
-                return response
+        with self._sync_lock:
+            cached = self.cache.pop(key, None)
+            if cached is not None:
+                response, timestamp = cached
+                if not self._is_expired(timestamp):
+                    self.hits += 1
+                    self.cache[key] = (response, timestamp)
+                    return response
 
-        # Cache miss - generate and cache
-        self.misses += 1
+            self.misses += 1
+
         if self.next_middleware:
             response = self.next_middleware.process_generate(prompt, **kwargs)
         elif self.model:
@@ -2093,13 +2094,11 @@ class CacheMiddleware(Middleware):
         else:
             raise ModelError("No model available in pipeline")
 
-        # Store in cache with LRU eviction
-        if len(self.cache) >= self.cache_size:
-            # Remove oldest entry
-            oldest_key = next(iter(self.cache))
-            del self.cache[oldest_key]
-
-        self.cache[key] = (response, time.time())
+        with self._sync_lock:
+            if len(self.cache) >= self.cache_size:
+                oldest_key = next(iter(self.cache))
+                del self.cache[oldest_key]
+            self.cache[key] = (response, time.time())
         return response
 
     async def aprocess_generate(self, prompt: str, **kwargs: Any) -> str:
@@ -2397,6 +2396,7 @@ class RateLimitMiddleware(Middleware):
         self.burst_size = burst_size if burst_size is not None else requests_per_minute
         self.tokens = float(self.burst_size)
         self.last_update = time.time()
+        self._sync_lock = threading.Lock()
 
     def _acquire_token(self) -> None:
         """Acquire a token from the bucket, waiting if necessary.
@@ -2415,19 +2415,19 @@ class RateLimitMiddleware(Middleware):
             >>> rate_mw = RateLimitMiddleware(requests_per_minute=60)
             >>> rate_mw._acquire_token()  # May wait if no tokens
         """
-        now = time.time()
-        elapsed = now - self.last_update
-        self.tokens = min(self.burst_size, self.tokens + elapsed * self.rate)
-        self.last_update = now
+        with self._sync_lock:
+            now = time.time()
+            elapsed = now - self.last_update
+            self.tokens = min(self.burst_size, self.tokens + elapsed * self.rate)
+            self.last_update = now
 
-        if self.tokens < 1.0:
-            # Wait for token to be available
-            wait_time = (1.0 - self.tokens) / self.rate
-            time.sleep(wait_time)
-            self.tokens = 1.0
-            self.last_update = time.time()
+            if self.tokens < 1.0:
+                wait_time = (1.0 - self.tokens) / self.rate
+                time.sleep(wait_time)
+                self.tokens = 1.0
+                self.last_update = time.time()
 
-        self.tokens -= 1.0
+            self.tokens -= 1.0
 
     def process_generate(self, prompt: str, **kwargs: Any) -> str:
         """Process a generate request with rate limiting.

--- a/insideLLMs/schemas/custom_trace_v1.py
+++ b/insideLLMs/schemas/custom_trace_v1.py
@@ -164,11 +164,18 @@ def _canonical_json_bytes(value: Any) -> bytes:
     --------
     _assert_jsonable : Validates JSON serialisability with error context
     """
+    from insideLLMs._serialization import StrictSerializationError, serialize_value
+
+    try:
+        serialized = serialize_value(value, strict=True)
+    except StrictSerializationError as exc:
+        raise TypeError(str(exc)) from exc
     return json.dumps(
-        value,
+        serialized,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
+        allow_nan=False,
     ).encode("utf-8")
 
 

--- a/insideLLMs/schemas/registry.py
+++ b/insideLLMs/schemas/registry.py
@@ -1858,4 +1858,16 @@ class SchemaRegistry:
         t = normalize_semver(to_version)
         if f == t:
             return custom_migration(data) if custom_migration else data
+        if (
+            schema_name == self.RUN_MANIFEST
+            and f == "1.0.0"
+            and t == "1.0.1"
+        ):
+            migrated = dict(data) if isinstance(data, dict) else data
+            if isinstance(migrated, dict):
+                migrated = custom_migration(migrated) if custom_migration else migrated
+                if isinstance(migrated, dict):
+                    migrated.setdefault("run_completed", False)
+                    migrated["schema_version"] = "1.0.1"
+            return migrated
         raise NotImplementedError(f"No migration registered for {schema_name}: {f} -> {t}")

--- a/tests/test_cli_diff_engine.py
+++ b/tests/test_cli_diff_engine.py
@@ -360,3 +360,73 @@ def test_interactive_helpers_contract(tmp_path: Path) -> None:
     copied = copy_candidate_artifacts_to_baseline(baseline, candidate)
     assert "records.jsonl" in copied
     assert (baseline / "records.jsonl").exists()
+
+
+def test_primary_metric_mismatch_blocks_score_fallback() -> None:
+    base = [_record(score=0.9)]
+    cand = [_record(score=0.7)]
+    base[0]["primary_metric"] = "accuracy"
+    base[0]["scores"] = {"score": 0.9}
+    cand[0]["primary_metric"] = "loss"
+    cand[0]["scores"] = {"score": 0.7}
+
+    computation = build_diff_computation(
+        records_baseline=base,
+        records_candidate=cand,
+        baseline_label="a",
+        candidate_label="b",
+    )
+    assert computation.regressions == []
+    assert computation.diff_report["counts"]["other_changes"] == 1
+    assert "primary_metric_mismatch" in computation.changes[0][3]
+
+
+def test_bool_scores_not_treated_as_numeric() -> None:
+    base = [_record(score=1.0)]
+    cand = [_record(score=0.0)]
+    base[0]["scores"] = {"score": True}
+    cand[0]["scores"] = {"score": False}
+
+    computation = build_diff_computation(
+        records_baseline=base,
+        records_candidate=cand,
+        baseline_label="a",
+        candidate_label="b",
+    )
+    assert computation.regressions == []
+
+
+def test_improvements_only_has_differences() -> None:
+    computation = build_diff_computation(
+        records_baseline=[_record(score=0.5)],
+        records_candidate=[_record(score=0.9)],
+        baseline_label="a",
+        candidate_label="b",
+    )
+    assert computation.improvements
+    assert computation.has_differences is True
+    assert compute_diff_exit_code(computation, DiffGatePolicy(fail_on_changes=True)) == 0
+
+
+def test_output_text_ignore_keys() -> None:
+    computation = build_diff_computation(
+        records_baseline=[_record(output_text='{"a":1,"ts":"x"}')],
+        records_candidate=[_record(output_text='{"a":1,"ts":"y"}')],
+        baseline_label="a",
+        candidate_label="b",
+        output_fingerprint_ignore=["ts"],
+    )
+    assert computation.changes == []
+
+
+def test_regression_and_output_change_both_reported() -> None:
+    base = [_record(score=0.9, output_text="alpha")]
+    cand = [_record(score=0.5, output_text="beta")]
+    computation = build_diff_computation(
+        records_baseline=base,
+        records_candidate=cand,
+        baseline_label="a",
+        candidate_label="b",
+    )
+    assert len(computation.regressions) == 1
+    assert any("output changed" in item[3] for item in computation.changes)

--- a/tests/test_cli_interactive_coverage.py
+++ b/tests/test_cli_interactive_coverage.py
@@ -110,7 +110,9 @@ class TestInteractiveCommand:
         mock_model = MagicMock()
         mock_model.generate.side_effect = RuntimeError("generation failed")
         with patch("builtins.input", side_effect=["test prompt", "quit"]):
-            with patch("insideLLMs.cli.commands.interactive.model_registry") as mock_registry:
-                mock_registry.get.return_value = mock_model
+            with patch(
+                "insideLLMs.cli.commands.interactive.resolve_registered_model",
+                return_value=mock_model,
+            ):
                 rc = cmd_interactive(_make_args(history_file=history_file))
         assert rc == 0

--- a/tests/test_cli_remaining_coverage.py
+++ b/tests/test_cli_remaining_coverage.py
@@ -122,17 +122,18 @@ class TestQuicktestCommand:
         assert rc == 1
 
     def test_quicktest_with_probe(self, capsys):
-        # Exercises the probe loading code path; may fail if registry returns instance
-        rc = cmd_quicktest(_quicktest_args(probe="factuality"))
-        assert rc in (0, 1)
-
-    def test_quicktest_long_prompt(self, capsys):
-        rc = cmd_quicktest(_quicktest_args(prompt="x" * 100))
+        rc = cmd_quicktest(_quicktest_args(probe="logic"))
+        captured = capsys.readouterr()
         assert rc == 0
+        assert "Probe: logic" in captured.out
 
-    def test_quicktest_with_model_args(self, capsys):
-        rc = cmd_quicktest(_quicktest_args(model_args='{"response_prefix": "test"}'))
+    def test_quicktest_model_args_applied(self, capsys):
+        rc = cmd_quicktest(
+            _quicktest_args(model_args='{"response_prefix": "PREFIX:"}', temperature=0.7)
+        )
+        captured = capsys.readouterr()
         assert rc == 0
+        assert "PREFIX:" in captured.out
 
 
 class TestRunCommand:

--- a/tests/test_cli_validate_benchmark_branches.py
+++ b/tests/test_cli_validate_benchmark_branches.py
@@ -199,7 +199,7 @@ def test_cmd_benchmark_explicit_datasets_and_html_report(tmp_path):
 
     with (
         patch("insideLLMs.benchmark_datasets.load_builtin_dataset", return_value=fake_dataset),
-        patch("insideLLMs.cli.commands.benchmark.model_registry.get", return_value=_Model),
+        patch("insideLLMs.cli.commands.benchmark.resolve_registered_model", return_value=_Model),
         patch("insideLLMs.cli.commands.benchmark.probe_registry.get", return_value=_Probe),
         patch("insideLLMs.runtime.runner.ProbeRunner", _Runner),
     ):
@@ -248,7 +248,8 @@ def test_cmd_benchmark_probe_load_failure_and_runner_errors(tmp_path):
             return_value=fake_suite,
         ),
         patch(
-            "insideLLMs.cli.commands.benchmark.model_registry.get", return_value=SimpleNamespace()
+            "insideLLMs.cli.commands.benchmark.resolve_registered_model",
+            return_value=SimpleNamespace(),
         ),
         patch(
             "insideLLMs.cli.commands.benchmark.probe_registry.get",

--- a/tests/test_misc_coverage.py
+++ b/tests/test_misc_coverage.py
@@ -97,7 +97,7 @@ class TestAssertJsonable:
         from insideLLMs.schemas.custom_trace_v1 import _assert_jsonable
 
         with pytest.raises(ValueError, match="events.payload must be JSON-serialisable"):
-            _assert_jsonable({"ts": datetime.now()}, where="events.payload")
+            _assert_jsonable({"bad": object()}, where="events.payload")
 
 
 class TestNormaliseSha256Value:
@@ -364,7 +364,7 @@ class TestTraceEventStored:
         from insideLLMs.schemas.custom_trace_v1 import TraceEventStored
 
         with pytest.raises(Exception, match="JSON-serialisable"):
-            TraceEventStored(seq=0, kind="msg", payload={"bad": datetime.now()})
+            TraceEventStored(seq=0, kind="msg", payload={"bad": object()})
 
 
 class TestTruncationModels:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the full six-phase bug remediation plan from the core audit.

### Phase 1 — CLI registry
- Add `resolve_registered_model()` with factory-kwarg filtering
- Fix `quicktest` probe crash and model-args handling
- Fix `generate-suite`, `compare`, `benchmark`, `interactive` registry usage
- Fix `init` interactive heuristic (no `sys.argv` counting)
- Benchmark now reports probe execution failures

### Phase 2 — Diff engine
- Block `primary_metric` mismatch before `"score"` fallback
- Reject boolean scores as numeric
- Apply `output_fingerprint_ignore` to JSON `output_text`
- Report co-occurring regressions + output/trace changes (no early `continue`)
- `has_differences` includes improvements
- Interactive diff review includes all change categories

### Phase 3 — Harness / runtime lifecycle
- Prepare run directory **before** harness execution (fail-fast)
- Default harness output to `~/.insidellms/runs/<run_id>/` (aligned with `run`)
- Resolve config `output_dir` relative to config file parent
- Preserve `metadata` on resume rebuild
- Batch `stop_on_error` breaks early; async fills skipped slots

### Phase 4 — Async / pipeline parity
- `prefer_async_pipeline=True` in async experiment + harness paths
- Thread locks on sync `CacheMiddleware` / `RateLimitMiddleware`
- Wire YAML `runner:` block; add `--timeout` and `--stop-on-error` to `run`

### Phase 5 — Registry / schema / determinism
- Warn on `ensure_builtins_registered()` ImportError (no silent swallow)
- Strict canonical JSON for custom trace hashing (unicode preserved)
- Implement `RunManifest` 1.0.0 → 1.0.1 migration
- Deterministic JSONL export via `stable_json_dumps`

### Phase 6 — Dedup / quirks
- `contrib/diffing.py` re-exports public facade
- `cli/_record_utils.py` re-exports runtime diff helpers (no drift)
- Propagate `ProbeResult.latency_ms`; `error_count` includes timeouts
- `_record_label` uses `replicate_key` when present
- Update `docs/GOLDEN_PATH.md` for harness output defaults

## Breaking changes

- Harness default output directory is now `~/.insidellms/runs/<run_id>/` instead of `./results/` when no `--run-dir` / `output_dir` is set
- Diff may report more categories per record (regression + output change)
- Cross-run `primary_metric` mismatch is `metrics_not_comparable`, not a score regression

## Test plan

- [x] `make golden-path`
- [x] `make test-fast` — 6495 passed
- [x] `tests/test_cli_diff_engine.py` — new edge-case tests
- [x] `tests/test_determinism_spine.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf5bb231-d7ac-4e6e-83a6-652e60896dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf5bb231-d7ac-4e6e-83a6-652e60896dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix core CLI, diff engine, and harness/runtime bugs while aligning async and sync execution paths and improving determinism of outputs and exports.

New Features:
- Allow experiment configs to specify runner settings via a `runner:` block, including concurrency, timeout, batching, and stop-on-error behavior.
- Support per-item async timeouts and stop-on-error semantics in the async experiment runner and `insidellms run` CLI.
- Expose a helper to resolve registered models with safe factory-kwargs filtering for CLI commands.

Bug Fixes:
- Ensure diff computations treat boolean scores as non-numeric, honor primary_metric mismatches before falling back to generic scores, and still detect improvements as differences.
- Apply output_fingerprint_ignore settings to both structured outputs and JSON-encoded output_text, and report both regressions and output changes for the same record when applicable.
- Make harness runs prepare the output directory before execution, default outputs to a stable run-root under the user home directory, and resolve config-relative output_dir paths correctly.
- Propagate probe latency_ms into recorded results, include timeouts in error_count, and preserve metadata on result reconstruction.
- Fix CLI quicktest, benchmark, compare, generate-suite, and interactive commands to consistently use the registry for model resolution and handle probe behavior without crashes.
- Prevent async runs from silently dropping skipped items when stop-on-error is triggered by marking remaining slots as skipped in results.

Enhancements:
- Share runtime diff helper functions with the CLI layer via re-exports to keep diff behavior consistent across surfaces.
- Extend interactive diff review to include improvements, trace drifts, trace violation changes, and trajectory drifts in the review lines.
- Make cache and rate-limit middlewares thread-safe via locks to avoid race conditions in synchronous pipelines.
- Warn explicitly when builtin registry registration fails due to missing imports instead of silently swallowing ImportError.
- Strengthen custom trace canonical JSON hashing by enforcing strict serialization and stable, non-NaN JSON encoding.
- Implement a migration path from RunManifest schema 1.0.0 to 1.0.1, adding a run_completed flag and bumping the stored schema version.
- Ensure JSONL export uses stable_json_dumps for deterministic line ordering and encoding.
- Improve the `insidellms init` interactive heuristic to trigger only for defaults-only invocations in a TTY.
- Refine CLI async run logging to reflect config/default concurrency when the flag is not explicitly set.

Documentation:
- Document the new default harness output directory behavior and configuration precedence in the GOLDEN_PATH guide.

Tests:
- Add targeted tests for CLI diff edge cases around metrics comparability, boolean scores, improvements-only diffs, output_text ignore keys, and concurrent regression plus output changes.
- Update CLI tests for quicktest, interactive, and benchmark flows to cover new registry resolution behavior, probe output, and patched middlewares.
- Adjust determinism and trace schema tests to reflect stricter JSON-serialisability requirements and the new error shapes.

Chores:
- Align CLI record utilities with runtime diffing helpers by delegating to the runtime module and cleaning up duplicated logic.