### PR TITLE
Production hardening (Phase 1): green the build, test + exception hygiene, coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           python -m pytest
           --cov
           --cov-report=term-missing
-          --cov-fail-under=80
+          --cov-fail-under=88
           -m "not slow and not integration and not performance"
 
   determinism:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           restore-keys: pip-test-${{ matrix.python-version }}-
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,providers,nlp,visualization]"
 
       - name: Run tests with coverage
         run: >

--- a/README.md
+++ b/README.md
@@ -239,6 +239,42 @@ for signing and [oras](https://oras.land/docs/installation) for OCI publishing.
 
 </details>
 
+<details>
+<summary><b>Trace & trajectory gating</b></summary>
+
+Beyond output text, `diff` can gate on structural drift in traces and agent
+trajectories:
+
+```bash
+insidellms diff ./baseline ./candidate --fail-on-trace-violations   # trace violations increased
+insidellms diff ./baseline ./candidate --fail-on-trace-drift        # trace fingerprints changed
+insidellms diff ./baseline ./candidate --fail-on-trajectory-drift   # agent step/tool sequence changed
+```
+
+`--fail-on-trajectory-drift` exits non-zero (code `5`) when an agent's step
+count, tool sequence, or tool-call arguments differ between runs -- even if the
+final answer is identical.
+
+</details>
+
+<details>
+<summary><b>Production shadow capture</b></summary>
+
+Sample live production traffic into canonical `records.jsonl` artefacts with a
+FastAPI middleware, then diff captured behaviour over time:
+
+```python
+from fastapi import FastAPI
+from insideLLMs import shadow
+
+app = FastAPI()
+app.middleware("http")(
+    shadow.fastapi(output_path="./shadow/records.jsonl", sample_rate=0.01)
+)
+```
+
+</details>
+
 ## Docs
 
 - [Documentation site](https://dr-gareth-roberts.github.io/insideLLMs/) -- full guides and reference

--- a/examples/example_nlp.py
+++ b/examples/example_nlp.py
@@ -133,11 +133,8 @@ def main():
         print(f"Readability calculation skipped: {e}")
 
     word_freq = get_word_frequencies(cleaned_text)
-    print(
-        f"Top 5 most frequent words: {
-            sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:5]
-        }"
-    )
+    top_words = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:5]
+    print(f"Top 5 most frequent words: {top_words}")
 
     # Basic text classification
     print("\n4. Basic Text Classification:")

--- a/insideLLMs/cli/_parsing.py
+++ b/insideLLMs/cli/_parsing.py
@@ -38,7 +38,18 @@ def _module_version(dist_name: str) -> str | None:
 
 
 def _has_module(module: str) -> bool:
-    return importlib.util.find_spec(module) is not None
+    """Return True if ``module`` can be located as an import spec.
+
+    ``importlib.util.find_spec`` raises (rather than returning ``None``) when a
+    parent package is missing for a dotted path -- e.g. ``google.generativeai``
+    when ``google`` is not installed -- so any import-time failure is treated as
+    "module not available". This keeps capability probing (``doctor``) robust to
+    absent optional dependencies instead of crashing.
+    """
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
 
 
 def _check_nltk_resource(path: str) -> bool:

--- a/insideLLMs/integrations/langchain.py
+++ b/insideLLMs/integrations/langchain.py
@@ -184,6 +184,8 @@ def as_langchain_chat_model(model: ModelProtocol):
                         try:
                             run_manager.on_llm_new_token(str(chunk))
                         except Exception:
+                            # A third-party LangChain callback raising must not
+                            # break token streaming; intentionally broad.
                             pass
                     yield ChatGenerationChunk(message=AIMessageChunk(content=str(chunk)))
             except Exception:

--- a/insideLLMs/resources.py
+++ b/insideLLMs/resources.py
@@ -374,7 +374,9 @@ def open_records_file(
         try:
             fp.flush()
             fp.close()
-        except Exception:
+        except (OSError, ValueError):
+            # Best-effort cleanup: flush/close can fail on an already-closed or
+            # broken stream; that must not mask the original error (if any).
             pass
 
 
@@ -551,7 +553,10 @@ def atomic_write_text(path: Path, text: str) -> None:
         f.flush()
         try:
             os.fsync(f.fileno())
-        except Exception:
+        except OSError:
+            # fsync is best-effort durability; some filesystems/platforms reject
+            # it. The atomic os.replace below is what guarantees consistency, so
+            # a failed fsync must not fail the write.
             pass
     os.replace(tmp, path)
 
@@ -921,7 +926,9 @@ def ensure_run_sentinel(run_dir: Path) -> None:
     if not marker.exists():
         try:
             marker.write_text("insideLLMs run directory\n", encoding="utf-8")
-        except Exception:
+        except OSError:
+            # The run-directory sentinel is advisory; failing to write it (e.g. a
+            # read-only filesystem) must not abort run setup.
             pass
 
 

--- a/insideLLMs/runtime/_base.py
+++ b/insideLLMs/runtime/_base.py
@@ -80,7 +80,10 @@ def _invoke_progress_callback(
             callback_style = "legacy"
         try:
             setattr(callback, "_insidellms_progress_style", callback_style)
-        except Exception:
+        except (AttributeError, TypeError):
+            # Caching the detected style on the callable is a micro-optimization;
+            # some callables (builtins, __slots__ objects) reject attribute
+            # assignment, in which case we simply re-detect on the next call.
             pass
 
     if callback_style == "legacy":

--- a/insideLLMs/runtime/_config_loader.py
+++ b/insideLLMs/runtime/_config_loader.py
@@ -11,7 +11,7 @@ import logging
 import os
 import posixpath
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import yaml
 
@@ -522,7 +522,7 @@ def _create_probe_from_config(config: ConfigDict) -> Probe:
         if probe_type not in probe_map:
             raise ValueError(f"Unknown probe type: {probe_type}") from None
 
-        return probe_map[probe_type](**probe_args)
+        return cast("Probe[Any]", probe_map[probe_type](**probe_args))
 
 
 def _load_dataset_from_config(config: ConfigDict, base_dir: Path) -> list[Any]:
@@ -553,7 +553,7 @@ def _load_dataset_from_config(config: ConfigDict, base_dir: Path) -> list[Any]:
         path = _resolve_path(config["path"], base_dir)
         try:
             loader = dataset_registry.get_factory(format_type)
-            return loader(str(path))
+            return cast("list[Any]", loader(str(path)))
         except NotFoundError:
             from insideLLMs.dataset_utils import load_csv_dataset, load_jsonl_dataset
 
@@ -579,7 +579,10 @@ def _load_dataset_from_config(config: ConfigDict, base_dir: Path) -> list[Any]:
         extra_kwargs = {k: v for k, v in config.items() if k not in excluded_keys}
         try:
             loader = dataset_registry.get_factory("hf")
-            return loader(config["name"], split=config.get("split", "test"), **extra_kwargs)
+            return cast(
+                "list[Any]",
+                loader(config["name"], split=config.get("split", "test"), **extra_kwargs),
+            )
         except NotFoundError:
             from insideLLMs.dataset_utils import load_hf_dataset
 

--- a/insideLLMs/runtime/_result_utils.py
+++ b/insideLLMs/runtime/_result_utils.py
@@ -9,7 +9,7 @@ import hashlib
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 from insideLLMs._serialization import (
     StrictSerializationError,
@@ -138,13 +138,13 @@ def _normalize_info_obj_to_dict(info_obj: Any) -> dict[str, Any]:
     if hasattr(info_obj, "dict") and callable(getattr(info_obj, "dict")):
         # pydantic v1 compatibility
         try:
-            return info_obj.dict()
+            return cast("dict[str, Any]", info_obj.dict())
         except Exception:
             return {}
     if hasattr(info_obj, "model_dump") and callable(getattr(info_obj, "model_dump")):
         # pydantic v2 compatibility
         try:
-            return info_obj.model_dump()
+            return cast("dict[str, Any]", info_obj.model_dump())
         except Exception:
             return {}
     return {}

--- a/insideLLMs/runtime/pipeline.py
+++ b/insideLLMs/runtime/pipeline.py
@@ -242,7 +242,7 @@ import asyncio
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from insideLLMs.exceptions import ModelError, RateLimitError, TimeoutError
 from insideLLMs.models.base import (
@@ -565,7 +565,7 @@ class Middleware(ABC):
         if self.next_middleware:
             return self.next_middleware.process_chat(messages, **kwargs)
         if self.model and hasattr(self.model, "chat"):
-            return self.model.chat(messages, **kwargs)
+            return cast(str, self.model.chat(messages, **kwargs))
         raise ModelError("No chat implementation available")
 
     def process_stream(self, prompt: str, **kwargs: Any) -> Iterator[str]:
@@ -761,7 +761,7 @@ class Middleware(ABC):
             return await self.next_middleware.aprocess_chat(messages, **kwargs)
         if self.model:
             if hasattr(self.model, "achat"):
-                return await self.model.achat(messages, **kwargs)
+                return cast(str, await self.model.achat(messages, **kwargs))
             if hasattr(self.model, "chat"):
                 loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, lambda: self.model.chat(messages, **kwargs))
@@ -2846,7 +2846,7 @@ class ModelPipeline(Model):
         if self.middlewares:
             return self.middlewares[0].process_chat(messages, **kwargs)
         if hasattr(self.base_model, "chat"):
-            return self.base_model.chat(messages, **kwargs)
+            return cast(str, self.base_model.chat(messages, **kwargs))
         raise ModelError("Base model does not support chat")
 
     def stream(self, prompt: str, **kwargs: Any) -> Iterator[str]:
@@ -2875,7 +2875,7 @@ class ModelPipeline(Model):
         if self.middlewares:
             return await self.middlewares[0].aprocess_chat(messages, **kwargs)
         if hasattr(self.base_model, "achat"):
-            return await self.base_model.achat(messages, **kwargs)
+            return cast(str, await self.base_model.achat(messages, **kwargs))
         if hasattr(self.base_model, "chat"):
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(

--- a/insideLLMs/runtime/reproducibility.py
+++ b/insideLLMs/runtime/reproducibility.py
@@ -182,7 +182,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 from insideLLMs._serialization import serialize_value as _serialize_value
 from insideLLMs._serialization import stable_json_dumps as _stable_json_dumps
@@ -1461,7 +1461,7 @@ class ExperimentCheckpointManager:
         checkpoint = self._checkpoints.get(checkpoint_id)
         if not checkpoint:
             return None
-        return checkpoint["state"]
+        return cast("dict[str, Any]", checkpoint["state"])
 
 
 @dataclass

--- a/insideLLMs/semantic_cache.py
+++ b/insideLLMs/semantic_cache.py
@@ -1102,6 +1102,10 @@ class RedisCache:
             # Count only value keys, not metadata keys
             self._stats.entry_count = len([k for k in keys if not k.endswith(":meta")])
         except Exception:
+            # Best-effort stats read against an external cache backend (redis):
+            # a backend/connection error must not break callers that only need
+            # the in-memory counters. Backend client exceptions are dynamic, so
+            # the broad catch is intentional.
             pass
         return self._stats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ disable_error_code = [
     "operator",
     "index",
     "var-annotated",
-    "no-any-return",
     "misc",
     "union-attr",
     "override",

--- a/tests/contrib/test_contrib_import_smoke.py
+++ b/tests/contrib/test_contrib_import_smoke.py
@@ -1,0 +1,43 @@
+"""Import/smoke guarantee for every ``insideLLMs.contrib`` module.
+
+Contrib modules are research/analysis utilities that are not part of the core
+pipeline. The contract enforced here: each one must import cleanly with only the
+core dependencies present. Heavy third-party packages must be imported lazily
+(inside functions), not at module top level, so a missing *optional external*
+dependency is tolerated (the case is skipped). A broken *internal* import
+(a missing ``insideLLMs.*`` module/attribute) is always a failure.
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import insideLLMs.contrib as contrib_pkg
+
+_CONTRIB_MODULES = sorted(
+    name
+    for _, name, is_pkg in pkgutil.iter_modules(contrib_pkg.__path__)
+    if not is_pkg and not name.startswith("_")
+)
+
+
+def test_contrib_modules_discovered():
+    """The contrib package should expose a non-trivial set of modules."""
+    assert len(_CONTRIB_MODULES) >= 30, _CONTRIB_MODULES
+
+
+@pytest.mark.parametrize("module_name", _CONTRIB_MODULES)
+def test_contrib_module_imports(module_name):
+    """Each contrib module imports; only a missing external dep may skip it."""
+    qualified = f"insideLLMs.contrib.{module_name}"
+    try:
+        module = importlib.import_module(qualified)
+    except ImportError as exc:
+        missing_root = (exc.name or "").split(".")[0]
+        if not missing_root or missing_root.startswith("insideLLMs"):
+            raise AssertionError(f"{qualified} has a broken internal import: {exc!r}") from exc
+        pytest.skip(f"{qualified} needs optional dependency '{missing_root}' (not installed)")
+
+    assert module is not None
+    assert module.__name__ == qualified

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,15 +59,18 @@ class TestColorize:
 
     def test_colorize_without_color_support(self):
         """Test colorize when color is disabled."""
-        import insideLLMs.cli as cli_module
+        # ``colorize`` reads the ``USE_COLOR`` flag defined in ``cli._output``;
+        # patch it at that source so the test is independent of the ambient
+        # terminal colour state (NO_COLOR/FORCE_COLOR/TTY).
+        from insideLLMs.cli import _output
 
-        original = cli_module.USE_COLOR
+        original = _output.USE_COLOR
         try:
-            cli_module.USE_COLOR = False
-            result = cli_module.colorize("test", cli_module.Colors.RED)
+            _output.USE_COLOR = False
+            result = _output.colorize("test", _output.Colors.RED)
             assert result == "test"
         finally:
-            cli_module.USE_COLOR = original
+            _output.USE_COLOR = original
 
 
 class TestProgressBar:

--- a/tests/test_determinism_canary.py
+++ b/tests/test_determinism_canary.py
@@ -142,6 +142,11 @@ def _run_cli(
 def _seeded_env(seed: str) -> dict[str, str]:
     env = os.environ.copy()
     env["PYTHONHASHSEED"] = seed
+    # Determinism checks compare the human-readable diff summary, which must not
+    # depend on the ambient terminal's colour settings. Pin colour off so the
+    # captured stdout is byte-stable regardless of NO_COLOR/FORCE_COLOR/TTY.
+    env["NO_COLOR"] = "1"
+    env.pop("FORCE_COLOR", None)
     return env
 
 


### PR DESCRIPTION
## Production hardening — Phase 1 (green baseline + first hardening pass)

Brings insideLLMs's **enforced** quality closer to its `Development Status :: 5 - Production/Stable` claim. This is a focused, fully-green first pass. The large type-debt burn-down and module-splitting are deliberately scoped as a documented **roadmap** (below) rather than rushed.

> Based off `feat/compliance-intelligence-20260304` so the diff is *only* the hardening work (4 commits).

### What this PR does

**1. Greens the build — CI was red on `main`.**
- **docs-audit (`scripts/audit_docs.py`) was failing** → README now documents `--fail-on-trajectory-drift` and `shadow.fastapi` (verified real features). This had been red-lighting both the test and contract jobs.
- **`examples/example_nlp.py` used a Python 3.12+ multi-line f-string** — the project targets 3.10+, so it failed `ruff check` (lint job) and would not even parse on 3.10/3.11. Made 3.10-compatible.
- **`cli/_parsing._has_module` crashed on missing optional deps.** `importlib.util.find_spec("google.generativeai")` *raises* when the parent `google` package is absent, so `insidellms doctor --capabilities` — the *diagnostic* command — crashed instead of reporting the provider unavailable. Now treats import failure as "not available".
- **CI test job installs providers** (`.[dev,providers,nlp,visualization]`) to match CLAUDE.md's documented dev env, so provider adapters are actually exercised and coverage is representative. (lint / typecheck / determinism / contracts jobs stay on `.[dev]`.)

**2. Test hardening.**
- Made 3 colour-sensitive tests **hermetic** (independent of ambient `NO_COLOR`/`FORCE_COLOR`/TTY): one patched the wrong symbol (`cli.USE_COLOR` instead of the `cli._output.USE_COLOR` that `colorize` actually reads); two leaked ambient colour into a subprocess whose stdout they string-matched. Confirmed ANSI does **not** leak into diff *artifacts* (only terminal output) — so this was test-env sensitivity, not a determinism defect.
- New parametrized **import/smoke test for all 39 `contrib/` modules** — fails on a broken internal import, skips only for a missing external dependency.

**3. Exception hygiene.** Narrowed 6 broad, silent `except Exception: pass` swallows in core to specific exception types (or kept broad **with an explicit rationale** for the 2 genuinely-dynamic external paths: redis backend, third-party LangChain callback). Behaviour-preserving — control flow is unchanged, but a genuinely unexpected error is no longer hidden (important for a regression-detection tool).

**4. Coverage gate** raised **80 → 88** (suite measures ~90.6%; headroom left for the 3.10/3.11/3.12 matrix, only 3.12 verified locally).

**5. Type-integrity burn-down — started + enforced.** `mypy insideLLMs` passes today only because 18 error codes are globally suppressed. This PR clears the **first** one — `no-any-return` — by fixing the 10 core functions that leaked `Any` from a concrete return type (behaviour-preserving `typing.cast`), then removing it from the suppression list so it is CI-enforced.

### Verification (all green)
`ruff`, `ruff format`, `mypy insideLLMs` (+ `--strict` on `injection.py`/`safety.py`), **pytest 6694 passed / 0 failed @ ~90.6% coverage**, `make golden-path` (0 regressions, byte-identical artifacts), contract tests (48 passed).

### Roadmap — deliberately deferred (large, separate efforts; mapped during this work)
- **Type-integrity burn-down (in progress: 1 of 18 codes cleared).** `no-any-return` is now enforced (above). Re-enabling the remaining **17** codes surfaces **~349 errors across ~50 core files** (heaviest: `runtime/diffing.py` 51, `cli/_record_utils.py` 30, `optimization.py` 26, `runtime/pipeline.py` 23, `analysis/visualization.py` 23 — predominantly Optional/`union-attr`). Continue per-code (e.g. `var-annotated` is the next most mechanical, ~20) then the larger semantic codes (`assignment` 59, `arg-type` 60, `union-attr` 104), removing each from the suppression list as it clears. This is the ideal workload for the parallel module-owned agents.
- **Oversized modules.** 38 core modules exceed 1,500 lines (largest `analysis/visualization.py` 4,114; `caching.py` 3,490). Split behind stable re-export shims (public API + artifact bytes preserved), golden-path-gated.
- **Broad exceptions.** ~139 remaining `except Exception` in core to narrow or justify.
- **Test quality.** Strengthen assertion-light "coverage" tests to assert behaviour.
- **`contrib/`** stays scoped to import + smoke (per agreed scope), not the full bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
