### PR TITLE
Type-integrity burn-down: enforce 7 mypy error codes (fix 22 type errors)

### DIFF
--- a/insideLLMs/analysis/evaluation.py
+++ b/insideLLMs/analysis/evaluation.py
@@ -3057,7 +3057,7 @@ class JudgeModel:
         Returns:
             List of JudgeResults.
         """
-        refs = references or [None] * len(prompts)
+        refs: list[Optional[str]] = references or [None] * len(prompts)
         return [self.evaluate(p, r, ref, **kwargs) for p, r, ref in zip(prompts, responses, refs)]
 
     def compare(

--- a/insideLLMs/analysis/export.py
+++ b/insideLLMs/analysis/export.py
@@ -169,6 +169,7 @@ from typing import (
     Protocol,
     TextIO,
     Union,
+    cast,
 )
 
 from insideLLMs.schemas.constants import DEFAULT_SCHEMA_VERSION
@@ -1259,7 +1260,7 @@ class JSONExporter(Exporter):
             with open(output, "w", encoding=self.config.encoding) as f:
                 f.write(content)
         else:
-            output.write(content)
+            cast(TextIO, output).write(content)
 
     def export_string(self, data: Any) -> str:
         """Export data to a JSON string.
@@ -1437,7 +1438,7 @@ class JSONLExporter(Exporter):
             with open(output, "w", encoding=self.config.encoding) as f:
                 f.write(content)
         else:
-            output.write(content)
+            cast(TextIO, output).write(content)
 
     def export_string(self, data: Any) -> str:
         """Export data to a JSONL-formatted string.
@@ -1733,7 +1734,7 @@ class CSVExporter(Exporter):
             with open(output, "w", encoding=self.config.encoding, newline="") as f:
                 f.write(content)
         else:
-            output.write(content)
+            cast(TextIO, output).write(content)
 
     def export_string(self, data: Any) -> str:
         """Export data to a CSV-formatted string.
@@ -1867,7 +1868,7 @@ class MarkdownExporter(Exporter):
             with open(output, "w", encoding=self.config.encoding) as f:
                 f.write(content)
         else:
-            output.write(content)
+            cast(TextIO, output).write(content)
 
     def export_string(self, data: Any) -> str:
         """Export data to Markdown string.

--- a/insideLLMs/analysis/visualization.py
+++ b/insideLLMs/analysis/visualization.py
@@ -3480,7 +3480,7 @@ def create_interactive_html_report(
 """
 
     # Add model comparison cards
-    model_stats = {}
+    model_stats: dict[str, dict[str, Any]] = {}
     for exp in experiments:
         model = exp.model_info.name
         if model not in model_stats:
@@ -3671,7 +3671,7 @@ def create_interactive_html_report(
     # Footer
     if generated_at is None:
         generated_at = max(
-            (exp.completed_at for exp in experiments if getattr(exp, "completed_at", None)),
+            (exp.completed_at for exp in experiments if exp.completed_at is not None),
             default=None,
         )
     generated_at_str = generated_at.strftime("%Y-%m-%d %H:%M:%S") if generated_at else "unknown"

--- a/insideLLMs/cli/commands/compare.py
+++ b/insideLLMs/cli/commands/compare.py
@@ -58,7 +58,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
                             for d in data
                         ]
                     elif isinstance(data, dict):
-                        inputs = [data.get("input", data.get("question", str(data)))]
+                        inputs = [str(data.get("input", data.get("question", str(data))))]
                     else:
                         inputs = [str(data)]
                 elif input_path.suffix == ".jsonl":

--- a/insideLLMs/cli/commands/report.py
+++ b/insideLLMs/cli/commands/report.py
@@ -40,7 +40,7 @@ def cmd_report(args: argparse.Namespace) -> int:
         print_error("No experiments could be reconstructed from records")
         return 1
 
-    run_ids = {record.get("run_id") for record in records if record.get("run_id")}
+    run_ids = {record["run_id"] for record in records if record.get("run_id")}
     run_id = sorted(run_ids)[0] if run_ids else None
     if run_id and len(run_ids) > 1:
         print_warning(f"Multiple run_ids found; using {run_id}")

--- a/insideLLMs/cli/commands/run.py
+++ b/insideLLMs/cli/commands/run.py
@@ -196,7 +196,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
             if raw_results:
                 latencies = [
-                    r.get("latency_ms")
+                    r["latency_ms"]
                     for r in raw_results
                     if r.get("status") == "success"
                     and isinstance(r.get("latency_ms"), (int, float))

--- a/insideLLMs/cost_tracking.py
+++ b/insideLLMs/cost_tracking.py
@@ -1628,7 +1628,7 @@ def quick_cost_estimate(
     num_requests: int,
     avg_input_tokens: int = 500,
     avg_output_tokens: int = 200,
-) -> dict[str, float]:
+) -> dict[str, str | float]:
     """Quick estimate for a batch of requests."""
     single_cost = calculate_cost(model_name, avg_input_tokens, avg_output_tokens)
     total_cost = single_cost * num_requests

--- a/insideLLMs/nlp/text_analysis.py
+++ b/insideLLMs/nlp/text_analysis.py
@@ -59,7 +59,7 @@ import math
 import re
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 from insideLLMs.nlp.tokenization import word_tokenize_regex
 
@@ -1735,7 +1735,7 @@ def score_response(
     return ResponseQualityScore.calculate(response, prompt, expected_length, required_keywords)
 
 
-def compare_responses(response1: str, response2: str, prompt: str) -> dict[str, dict]:
+def compare_responses(response1: str, response2: str, prompt: str) -> dict[str, Any]:
     """
     Compare two LLM responses to the same prompt.
 

--- a/insideLLMs/retry.py
+++ b/insideLLMs/retry.py
@@ -104,6 +104,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Literal,
     Optional,
     TypeVar,
 )
@@ -1936,7 +1937,7 @@ class CircuitBreaker:
 
         return self
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Literal[False]:
         """Exit the circuit breaker context manager.
 
         Records success or failure based on whether an exception occurred

--- a/insideLLMs/runtime/diffing.py
+++ b/insideLLMs/runtime/diffing.py
@@ -832,10 +832,10 @@ def build_diff_computation(
         "candidate": candidate_label,
         "run_ids": {
             "baseline": sorted(
-                {record.get("run_id") for record in records_baseline if record.get("run_id")}
+                {record["run_id"] for record in records_baseline if record.get("run_id")}
             ),
             "candidate": sorted(
-                {record.get("run_id") for record in records_candidate if record.get("run_id")}
+                {record["run_id"] for record in records_candidate if record.get("run_id")}
             ),
         },
         "counts": {

--- a/insideLLMs/structured.py
+++ b/insideLLMs/structured.py
@@ -170,10 +170,12 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Generic,
     Optional,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
 )
@@ -1306,12 +1308,13 @@ def parse_to_type(data: Any, output_type: type[T]) -> T:
         return data
 
     elif output_type in (str, int, float, bool):
-        return output_type(data)
+        return cast("Callable[..., T]", output_type)(data)
 
     else:
         # Try direct instantiation
         try:
-            return output_type(**data) if isinstance(data, dict) else output_type(data)
+            ctor = cast("Callable[..., T]", output_type)
+            return ctor(**data) if isinstance(data, dict) else ctor(data)
         except Exception as e:
             raise ParsingError(f"Failed to create {output_type}: {e}", str(data)) from e
 

--- a/insideLLMs/types.py
+++ b/insideLLMs/types.py
@@ -993,7 +993,7 @@ class ProbeScore:
     mean_latency_ms: Optional[float] = None
     total_tokens: Optional[int] = None
     error_rate: float = 0.0
-    custom_metrics: dict[str, float] = field(default_factory=dict)
+    custom_metrics: dict[str, float | str] = field(default_factory=dict)
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,12 +179,6 @@ disable_error_code = [
     "attr-defined",
     "arg-type",
     "assignment",
-    "call-arg",
-    "call-overload",
-    "dict-item",
-    "exit-return",
-    "has-type",
-    "list-item",
     "operator",
     "index",
     "var-annotated",
@@ -192,7 +186,6 @@ disable_error_code = [
     "misc",
     "union-attr",
     "override",
-    "type-var",
     "import-untyped",
 ]
 


### PR DESCRIPTION
## Summary

Continues the mypy **type-integrity burn-down**: removes the next cheap tranche of codes from `disable_error_code` in `pyproject.toml` and fixes the 22 errors they surface on `main`. All fixes are type-honest and behavior-preserving.

## Codes re-enabled (errors fixed)

| code | errors | fix |
|---|---|---|
| `has-type` | 0 | free win |
| `exit-return` | 1 | `CircuitBreaker.__exit__` → `Literal[False]` |
| `call-arg` | 2 | `parse_to_type`: cast `output_type` to `Callable[..., T]` |
| `list-item` | 2 | typed `JudgeModel` refs; `str()` the dict-input branch |
| `call-overload` | 6 | `model_stats` annotation; `cast(TextIO)` on text exporters |
| `type-var` | 6 | subscript instead of `.get()`; narrow `completed_at is not None` |
| `dict-item` | 5 | widen `ProbeScore.custom_metrics`; 2 return-type widenings |

`reproducibility.list_all` was already fixed on `main`, so 22 errors here (not 24).

## Why behavior-preserving

- `record["run_id"]` / `r["latency_ms"]` are guarded by the same truthy `.get()` filters, so values are identical at runtime.
- `cast(...)` is a no-op at runtime; annotation widenings don't change values.
- `str()` wrap in `compare` matches the sibling branches that already stringify.

## Verification (against `main`)

- `make typecheck` (`mypy insideLLMs`): **Success, 217 files**
- `mypy --strict` on injection.py/safety.py: **Success**
- type coverage: **93.4%** (≥ 90% gate)
- `ruff check` + `ruff format --check`: **clean**
- fast suite (`NO_COLOR=1`, matching CI's non-TTY env): **6903 passed**, 1 pre-existing env-only failure (`test_fetch_dataset_refuses_implicit_mock`, also fails on clean `main`)

## Remaining disabled (follow-up PRs)

`attr-defined`, `arg-type`, `assignment`, `operator`, `index`, `var-annotated`, `no-any-return`, `misc`, `union-attr`, `override`, `import-untyped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten static typing by re-enabling several mypy error codes and fixing the surfaced issues across runtime, CLI, analysis, and support modules while preserving runtime behavior.

Bug Fixes:
- Ensure JSON/CSV/Markdown exporters only treat non-path outputs as text streams via explicit TextIO casting.
- Guarantee CircuitBreaker context manager exit return type is always False to match context protocol expectations.
- Avoid None-valued model completion times when computing report timestamps by filtering on non-None completed_at values.
- Prevent missing run_id and latency_ms lookups by relying on required dictionary keys in reporting and diffing code.
- Align CLI compare input handling by consistently stringifying dict-based inputs for comparison workflows.

Enhancements:
- Strengthen type safety of structured parsing by casting output_type to a callable constructor before use.
- Annotate model_stats structures, evaluation reference lists, and NLP comparison return types with more precise type hints.
- Widen type annotations for cost estimation outputs and ProbeScore custom metrics to reflect actual value shapes.
- Adjust mypy configuration to stop ignoring several error codes, increasing overall type integrity of the project.

Build:
- Update mypy configuration in pyproject.toml to re-enable multiple previously disabled error codes.