### PR TITLE
perf: avoid re-tokenizing selected examples per candidate in FewShotSelector

### DIFF
--- a/insideLLMs/optimization.py
+++ b/insideLLMs/optimization.py
@@ -1712,13 +1712,29 @@ class FewShotSelector:
                 best = None
                 best_score = -1
 
+                # Hoist values derived from ``selected`` out of the per-candidate
+                # loop: they only change once per outer iteration, not per
+                # candidate. Rebuilding them for every candidate made selection
+                # O(candidates * selected) instead of O(candidates). The
+                # tokenized word sets are also precomputed here so
+                # ``_calculate_diversity`` does not re-tokenize every selected
+                # input on each of the (potentially thousands of) calls.
+                selected_examples = [s["example"] for s in selected]
+                selected_inputs = [
+                    s["example"].get(input_key, "") for s in selected
+                ]
+                selected_word_sets = [
+                    set(text.lower().split()) for text in selected_inputs
+                ]
+
                 for candidate in scored_examples:
-                    if candidate["example"] in [s["example"] for s in selected]:
+                    if candidate["example"] in selected_examples:
                         continue
 
                     diversity = self._calculate_diversity(
                         candidate["example"].get(input_key, ""),
-                        [s["example"].get(input_key, "") for s in selected],
+                        selected_inputs,
+                        selected_word_sets,
                     )
 
                     combined = (1 - self.diversity_weight) * candidate[
@@ -1821,7 +1837,12 @@ class FewShotSelector:
         overlap = len(query_words & example_words)
         return overlap / len(query_words)
 
-    def _calculate_diversity(self, candidate: str, selected: list[str]) -> float:
+    def _calculate_diversity(
+        self,
+        candidate: str,
+        selected: list[str],
+        selected_word_sets: Optional[list[set]] = None,
+    ) -> float:
         """Calculate how different a candidate is from selected examples.
 
         Uses Jaccard distance (1 - Jaccard similarity) to measure diversity.
@@ -1834,6 +1855,13 @@ class FewShotSelector:
             The candidate example input text.
         selected : list of str
             List of input texts from already-selected examples.
+        selected_word_sets : list of set, optional
+            Pre-tokenized word sets for ``selected``. When provided, the
+            tokenization of the already-selected inputs is reused instead of
+            being recomputed on every call. Callers that invoke this method
+            repeatedly against the same ``selected`` collection (as the greedy
+            selection loop does, once per candidate) should pass this to avoid
+            redundant O(selected) tokenization per call.
 
         Returns
         -------
@@ -1857,11 +1885,14 @@ class FewShotSelector:
 
         candidate_words = set(candidate.lower().split())
 
+        if selected_word_sets is None:
+            selected_word_sets = [set(sel.lower().split()) for sel in selected]
+
         similarities = []
-        for sel in selected:
-            sel_words = set(sel.lower().split())
-            if candidate_words | sel_words:
-                sim = len(candidate_words & sel_words) / len(candidate_words | sel_words)
+        for sel_words in selected_word_sets:
+            union = candidate_words | sel_words
+            if union:
+                sim = len(candidate_words & sel_words) / len(union)
                 similarities.append(sim)
 
         if not similarities:

--- a/insideLLMs/optimization.py
+++ b/insideLLMs/optimization.py
@@ -1720,12 +1720,8 @@ class FewShotSelector:
                 # ``_calculate_diversity`` does not re-tokenize every selected
                 # input on each of the (potentially thousands of) calls.
                 selected_examples = [s["example"] for s in selected]
-                selected_inputs = [
-                    s["example"].get(input_key, "") for s in selected
-                ]
-                selected_word_sets = [
-                    set(text.lower().split()) for text in selected_inputs
-                ]
+                selected_inputs = [s["example"].get(input_key, "") for s in selected]
+                selected_word_sets = [set(text.lower().split()) for text in selected_inputs]
 
                 for candidate in scored_examples:
                     if candidate["example"] in selected_examples:

--- a/insideLLMs/optimization.py
+++ b/insideLLMs/optimization.py
@@ -1714,11 +1714,14 @@ class FewShotSelector:
 
                 # Hoist values derived from ``selected`` out of the per-candidate
                 # loop: they only change once per outer iteration, not per
-                # candidate. Rebuilding them for every candidate made selection
-                # O(candidates * selected) instead of O(candidates). The
-                # tokenized word sets are also precomputed here so
-                # ``_calculate_diversity`` does not re-tokenize every selected
-                # input on each of the (potentially thousands of) calls.
+                # candidate. Previously each candidate rebuilt the membership
+                # list and re-derived the selected inputs (O(selected) of
+                # allocation per candidate), and ``_calculate_diversity``
+                # re-tokenized every selected input on each of the (potentially
+                # thousands of) calls. Precomputing the inputs and their
+                # tokenized word sets here removes that redundant per-candidate
+                # allocation and tokenization. The diversity scoring itself is
+                # still O(candidates * selected); this cuts the constant factor.
                 selected_examples = [s["example"] for s in selected]
                 selected_inputs = [s["example"].get(input_key, "") for s in selected]
                 selected_word_sets = [set(text.lower().split()) for text in selected_inputs]
@@ -1837,7 +1840,7 @@ class FewShotSelector:
         self,
         candidate: str,
         selected: list[str],
-        selected_word_sets: Optional[list[set]] = None,
+        selected_word_sets: Optional[list[set[str]]] = None,
     ) -> float:
         """Calculate how different a candidate is from selected examples.
 
@@ -1857,7 +1860,9 @@ class FewShotSelector:
             being recomputed on every call. Callers that invoke this method
             repeatedly against the same ``selected`` collection (as the greedy
             selection loop does, once per candidate) should pass this to avoid
-            redundant O(selected) tokenization per call.
+            redundant O(selected) tokenization per call. Must align
+            element-for-element with ``selected``; a cache whose length does not
+            match ``selected`` is ignored and recomputed.
 
         Returns
         -------
@@ -1881,7 +1886,10 @@ class FewShotSelector:
 
         candidate_words = set(candidate.lower().split())
 
-        if selected_word_sets is None:
+        # Recompute when no cache is supplied, or when a supplied cache does not
+        # correspond element-for-element to ``selected`` (guards against a
+        # mismatched/stale cache silently producing wrong diversity scores).
+        if selected_word_sets is None or len(selected_word_sets) != len(selected):
             selected_word_sets = [set(sel.lower().split()) for sel in selected]
 
         similarities = []


### PR DESCRIPTION
## Summary

`FewShotSelector.select` greedily selects N examples from a pool by scoring **every candidate** against the already-selected set on **every** selection round. Profiling the inner loop showed redundant work that only depends on the selected set was being recomputed once per candidate:

- The membership list `[s["example"] for s in selected]` and the selected-inputs list were rebuilt for each candidate.
- `_calculate_diversity` re-tokenized every selected input (`set(sel.lower().split())`) on each call — i.e. `candidates × selected` tokenizations per round.

This change hoists those values out of the per-candidate loop and precomputes the tokenized word sets **once per selection round**, passing them into `_calculate_diversity`. Tokenization work drops from `O(candidates × selected)` to `O(selected)` per round.

## Why this one

This was selected as the highest-impact / lowest-effort item from a perf scan of the library. Most other candidates were regex "compile-on-every-call" patterns, but Python's built-in `re` cache already absorbs those, so they showed no measurable win. This change removes genuinely redundant algorithmic work instead.

## Safety / compatibility

- `_calculate_diversity` keeps its existing signature; the new `selected_word_sets` parameter is **optional** and falls back to computing the sets, so external callers and documented behaviour are unchanged.
- Output is **byte-for-byte identical** before/after (verified on randomized inputs).
- All 132 tests in `tests/contrib/test_optimization.py` and `tests/contrib/test_context_window_coverage.py` pass.

## Scope

One file, `insideLLMs/optimization.py` (+38 / -7).

## Summary by Sourcery

Optimize few-shot example selection by reusing precomputed data for selected examples during greedy selection rounds.

Enhancements:
- Precompute selected examples, their inputs, and tokenized word sets once per selection round instead of per candidate to reduce redundant work in few-shot selection.
- Extend `_calculate_diversity` with an optional pre-tokenized `selected_word_sets` parameter while preserving backward compatibility and behavior.