### PR TITLE
fix: resolve verified findings from codebase audit sweep

### DIFF
--- a/insideLLMs/benchmark_datasets.py
+++ b/insideLLMs/benchmark_datasets.py
@@ -1998,10 +1998,8 @@ def create_comprehensive_benchmark_suite(
                 random.seed(seed)
             examples = random.sample(examples, max_examples_per_dataset)
 
-        # Add source info
-        for example in examples:
-            example.source = name
-
+        # Source is recorded per-example via metadata["source_dataset"] below;
+        # avoid mutating the shared dataset objects' .source attribute.
         for example in examples:
             builder.add_example(
                 input_text=example.input_text,

--- a/insideLLMs/contrib/calibration.py
+++ b/insideLLMs/contrib/calibration.py
@@ -1729,7 +1729,6 @@ class HistogramBinner:
         if not confidences or len(confidences) != len(labels):
             raise ValueError("Invalid input")
 
-        1.0 / self.n_bins
         bin_sums = [0.0] * self.n_bins
         bin_counts = [0] * self.n_bins
 

--- a/insideLLMs/contrib/chains.py
+++ b/insideLLMs/contrib/chains.py
@@ -2537,6 +2537,7 @@ class Chain:
 
             start_time = time.time()
             step_status = ChainStatus.RUNNING
+            step_input = current_data
 
             try:
                 # Validate input
@@ -2588,7 +2589,7 @@ class Chain:
                 step_name=step.name,
                 step_type=step.step_type,
                 status=step_status,
-                input_data=current_data if step_status == ChainStatus.FAILED else input_data,
+                input_data=step_input,
                 output_data=current_data if step_status == ChainStatus.COMPLETED else None,
                 start_time=start_time,
                 end_time=end_time,

--- a/insideLLMs/contrib/conversation.py
+++ b/insideLLMs/contrib/conversation.py
@@ -2193,12 +2193,9 @@ class TopicTracker:
         if curr_topic in self._topic_history[:-1]:
             return TopicTransition.RETURN_TO_PREVIOUS
 
-        # Simple heuristic for transition type
-        # In practice, this would use more sophisticated NLP
-        if prev_topic.split()[0] == curr_topic.split()[0] if " " in prev_topic else False:
-            return TopicTransition.NATURAL_SHIFT
-
-        return TopicTransition.NATURAL_SHIFT  # Default to natural shift
+        # Simple heuristic for transition type; in practice this would use more
+        # sophisticated NLP. For now every remaining case is a natural shift.
+        return TopicTransition.NATURAL_SHIFT
 
     def analyze(self) -> TopicAnalysis:
         """Generate a comprehensive topic analysis report.

--- a/insideLLMs/contrib/distributed.py
+++ b/insideLLMs/contrib/distributed.py
@@ -2122,7 +2122,6 @@ class LocalDistributedExecutor:
         True
         """
         start_time = time.time()
-        self.work_queue.size + len(self._workers)  # Rough estimate
 
         while self.work_queue.size > 0 or any(
             w.info.status == WorkerStatus.BUSY for w in self._workers

--- a/insideLLMs/crypto/canonical.py
+++ b/insideLLMs/crypto/canonical.py
@@ -43,7 +43,7 @@ def canonical_json_bytes(
     ----------
     obj : Any
         JSON-serializable object to canonicalize.
-    canon_version : str, default "canon_v1"
+    canon_version : str, default "canon_v2"
         Version tag for the canonicalization scheme.
     strict : bool, default False
         If True, raise on non-JSON-serializable values.
@@ -112,7 +112,7 @@ def digest_obj(
         Object to canonicalize and hash.
     algo : str, default "sha256"
         Hash algorithm.
-    canon_version : str, default "canon_v1"
+    canon_version : str, default "canon_v2"
         Canonicalization version.
     purpose : str, default "record"
         Purpose tag (e.g. record, receipt, dataset_example, attestation).

--- a/insideLLMs/schemas/registry.py
+++ b/insideLLMs/schemas/registry.py
@@ -1660,14 +1660,14 @@ class SchemaRegistry:
 
         custom_migration : Callable[[Any], Any], optional
             A callable that transforms the data. If provided, it's applied
-            after version normalization (when from_version and to_version
-            normalize to the same value).
+            after version normalization.
 
             The callable:
             - Receives the data as its single argument
             - Should return the transformed data
             - Can modify the input in-place or return a new object
-            - Is only called for identity migrations (same normalized version)
+            - Is applied for identity migrations (same normalized version)
+              and for the RunManifest 1.0.0 -> 1.0.1 cross-version migration
 
         Returns
         -------


### PR DESCRIPTION
A deep per-module audit of the whole `insideLLMs` package (batched read-only auditor agents) surfaced a small number of genuine defects. Each was independently re-verified before fixing; false-positive candidates (honestly-documented "reserved" params, `__exit__` `exc_tb`, legitimate latency-measurement wall-clock in `contrib/`, illustrative seeded-random docstring outputs, etc.) were deliberately left untouched.

## Fixes (7 files, 8 defects)

| File | Class | What |
|------|-------|------|
| `crypto/canonical.py` (×2) | false-doc | docstrings said `canon_version` default `"canon_v1"`; actual default is `DEFAULT_CANON_VERSION = "canon_v2"` |
| `schemas/registry.py` | false-doc | `custom_migration` doc said "only identity migrations"; code also applies it in the RunManifest `1.0.0 → 1.0.1` cross-version branch |
| `benchmark_datasets.py` | bug | removed `example.source = name` — it mutated shared registry-owned `DatasetExample` objects but was never read (source is recorded via `metadata["source_dataset"]`) |
| `contrib/conversation.py` | dead code | removed an `if` whose branch and the fallthrough both returned `TopicTransition.NATURAL_SHIFT` |
| `contrib/calibration.py` | dead code | removed bare `1.0 / self.n_bins` expression statement (computed, never assigned/used) |
| `contrib/distributed.py` | dead code | removed bare `self.work_queue.size + len(self._workers)` expression statement (no-op) |
| `contrib/chains.py` | bug | step records logged the *chain's* original input for COMPLETED steps (because `current_data` was reassigned to the output); now captures `step_input` before execution so each step records its actual input |

All changes are doc-only or behaviour-preserving except the `chains.py` step-record fix (corrects the recorded `input_data`) and the `benchmark_datasets.py` side-effect removal — both verified by tests.

## Verification
- `ruff check` + `ruff format --check`: clean
- `mypy` on changed core files: clean
- targeted tests green: `crypto_canonical`, `schemas_registry`, `registry`, `benchmark_datasets` (62), `conversation` (79), and contrib chains/calibration/distributed (220 passed)
- determinism marker (`-m determinism`, `NO_COLOR=1`): 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)