### PR TITLE
docs: correct estimate_tokens docstring example (3, not 4)

### DIFF
--- a/insideLLMs/contrib/context_window.py
+++ b/insideLLMs/contrib/context_window.py
@@ -1017,7 +1017,7 @@ def estimate_tokens(text: str) -> int:
 
     >>> from insideLLMs.contrib.context_window import estimate_tokens
     >>> estimate_tokens("Hello, world!")
-    4
+    3
 
     Estimating tokens for longer text:
 


### PR DESCRIPTION
`insideLLMs/contrib/context_window.py` documented `estimate_tokens("Hello, world!")` as returning `4`, but it returns `3` (13 chars ÷ 4 = 3.25, truncated). Verified by running the function. The implementation is a correct approximation — only the docstring example was stale.

This was the one genuine residual from the deep audit's contrib sweep (the other flagged docstring examples were verified to be either correct, illustrative broken/empty-state values, or non-deterministic — and left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update estimate_tokens docstring example to show the correct return value for "Hello, world!".